### PR TITLE
Configurable token deletion and creation

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-  ignore = E111, E113, E114, E121
+  ignore = E111, E113, E114, E121, E125

--- a/idaplugin/rematch/config.py
+++ b/idaplugin/rematch/config.py
@@ -18,6 +18,10 @@ class Config(dict):
         "update": {
             "autocheck": true,
             "autoupdate": true
+        },
+        "login": {
+            "autologin": true,
+            "autologout": false
         }
     },
     "username": ""

--- a/idaplugin/rematch/dialogs/settings.py
+++ b/idaplugin/rematch/dialogs/settings.py
@@ -14,6 +14,8 @@ class SettingsDialog(base.BaseDialog):
 
     autoupdate = config['settings']['update']['autoupdate']
     autocheck = config['settings']['update']['autocheck']
+    autologin = config['settings']['login']['autologin']
+    autologout = config['settings']['login']['autologout']
 
     layout = QtWidgets.QVBoxLayout()
 
@@ -27,6 +29,16 @@ class SettingsDialog(base.BaseDialog):
                                           "version on startup")
     self.autoupdate.setChecked(autoupdate)
     layout.addWidget(self.autoupdate)
+
+    self.autologin = QtWidgets.QCheckBox("Automatically login using "
+                                         "user/password on startup")
+    self.autologin.setChecked(autologin)
+    layout.addWidget(self.autologin)
+
+    self.autologout = QtWidgets.QCheckBox("Automatically forget login "
+                                          "token when IDA exits")
+    self.autologout.setChecked(autologout)
+    layout.addWidget(self.autologout)
 
     saveBtn = QtWidgets.QPushButton("&Save")
     saveBtn.setDefault(True)
@@ -48,10 +60,14 @@ class SettingsDialog(base.BaseDialog):
   def data(self):
     autocheck = self.autocheck.isChecked()
     autoupdate = self.autoupdate.isChecked()
+    autologin = self.autologin.isChecked()
+    autologout = self.autologout.isChecked()
 
-    return autocheck, autoupdate
+    return autocheck, autoupdate, autologin, autologout
 
   def submit(self):
     config['settings']['update']['autocheck'] = self.autocheck.isChecked()
     config['settings']['update']['autoupdate'] = self.autoupdate.isChecked()
+    config['settings']['login']['autologin'] = self.autologin.isChecked()
+    config['settings']['login']['autologout'] = self.autologout.isChecked()
     self.accept()

--- a/idaplugin/rematch/plugin.py
+++ b/idaplugin/rematch/plugin.py
@@ -105,6 +105,8 @@ class RematchPlugin(idaapi.plugin_t):
       self.statusbar_timer.stop()
       self.statusbar_timer = None
 
+    if config['settings']['login']['autologout']:
+      del config['token']
     config.save()
 
   def __del__(self):

--- a/idaplugin/rematch/user.py
+++ b/idaplugin/rematch/user.py
@@ -9,17 +9,24 @@ class User(dict):
                     "is_staff": False, "is_active": False, "id": None}
 
   def __init__(self):
+    super(User, self).__init__(self.LOGGEDOUT_USER)
+
     try:
       if 'token' in config:
         self.refresh()
-      elif 'username' in config and \
-           'password' in config and \
-           'server' in config:
+
+      # refresh was successful
+      if self['is_authenticated']:
+        return
+
+      # only attempt user auto login if configured
+      if not config['settings']['login']['autologin']:
+        return
+
+      if 'username' in config and 'password' in config and 'server' in config:
         self.login(config['username'], config['password'], config['server'])
     except exceptions.RematchException as ex:
       logger('user').debug(ex)
-      data = self.LOGGEDOUT_USER
-      super(User, self).__init__(data)
 
   def login(self, username, password, server):
     # authenticate


### PR DESCRIPTION
Allows the user to configure token handling on start and end of IDA.
user can set to automatically delete login token when exiting IDA.
user can set to automatically login using username/password when no token is present

Signed-off-by: Nir Izraeli <nirizr@gmail.com>