### PR TITLE
Fix timespent progressbar never cycles

### DIFF
--- a/idaplugin/rematch/plugin.py
+++ b/idaplugin/rematch/plugin.py
@@ -80,7 +80,7 @@ class RematchPlugin(idaapi.plugin_t):
     timespent = self.timespent
 
     def update_timespent():
-        timespent.setValue(timespent.value() + 1 % (60 * 60))
+        timespent.setValue((timespent.value() + 1) % (60 * 60 + 1))
     self.timespent_timer.timeout.connect(update_timespent)
     self.timespent_timer.start()
 


### PR DESCRIPTION
due to order of operations bug, timespent never cycled back to zero

Signed-off-by: Nir Izraeli <nirizr@gmail.com>