### PR TITLE
This is a temp fix for a situation when a new db is created or a diff…

### DIFF
--- a/idaplugin/rematch/exceptions.py
+++ b/idaplugin/rematch/exceptions.py
@@ -1,4 +1,3 @@
-from json import loads
 
 class RematchException(Exception):
   message = ""
@@ -44,15 +43,13 @@ class NotFoundException(QueryException):
 class UnknownQueryException(Exception):
   message = ("Local error has occured! please report a reproducable bug if "
              "this issue persists")
-  
+
   def __init__(self, response=None, **kwargs):
     super(UnknownQueryException, self).__init__(**kwargs)
-    self.response = response 
+    self.response = response
 
   def __str__(self):
     if "Invalid pk" in self.response['file'][0]:
-      self.message = ("Invalid ID found, did you accidently switched a server ? ")
+      self.message = ("Invalid ID found, did you accidently switched"
+      "a server ? ")
     return "<{}: {}, {}>".format(self.__class__, self.response, self.message)
-   
-
-

--- a/idaplugin/rematch/exceptions.py
+++ b/idaplugin/rematch/exceptions.py
@@ -50,6 +50,6 @@ class UnknownQueryException(Exception):
 
   def __str__(self):
     if "Invalid pk" in self.response['file'][0]:
-      self.message = ("Invalid ID found, did you accidently switched"
-      "a server ? ")
+      self.message = ("Invalid ID found, did you accidently switched "
+                      "a server ? ")
     return "<{}: {}, {}>".format(self.__class__, self.response, self.message)

--- a/idaplugin/rematch/exceptions.py
+++ b/idaplugin/rematch/exceptions.py
@@ -1,3 +1,5 @@
+from json import loads
+
 class RematchException(Exception):
   message = ""
 
@@ -37,3 +39,20 @@ class AuthenticationException(RematchException):
 class NotFoundException(QueryException):
   message = ("Asset not found. This could be either a plugin error or a "
              "server error.")
+
+
+class UnknownQueryException(Exception):
+  message = ("Local error has occured! please report a reproducable bug if "
+             "this issue persists")
+  
+  def __init__(self, response=None, **kwargs):
+    super(UnknownQueryException, self).__init__(**kwargs)
+    self.response = response 
+
+  def __str__(self):
+    if "Invalid pk" in self.response['file'][0]:
+      self.message = ("Invalid ID found, did you accidently switched a server ? ")
+    return "<{}: {}, {}>".format(self.__class__, self.response, self.message)
+   
+
+

--- a/idaplugin/rematch/network.py
+++ b/idaplugin/rematch/network.py
@@ -111,7 +111,7 @@ def query(method, url, server=None, token=None, params=None, json=False):
     logger('network').debug(return_obj)
     logger('network').debug(ex.__dict__)
     err_codes = {500: exceptions.ServerException,
-                 400: exceptions.QueryException,
+                 400: exceptions.UnknownQueryException,
                  401: exceptions.AuthenticationException,
                  404: exceptions.NotFoundException}
     if ex.code in err_codes:


### PR DESCRIPTION
… server is used by the same idb

the idaplugin contains a netnode which saves the project id (pk) and tries to access it
if it's invalid, the server would return 400 we would faecpalm

This temp fix basically tries to see if we got "Invalid pk" from the server and warn the user
that the server may have been changed.
We should handle this better in future releases.