### PR TITLE
Partially fix moved/gone db issue.

### DIFF
--- a/idaplugin/rematch/actions/match.py
+++ b/idaplugin/rematch/actions/match.py
@@ -41,10 +41,12 @@ class MatchAllAction(base.BoundFileAction):
         data = e.response()
         if "Invalid pk" in data['file'][0]:
           logger('match').error("Something wrong happened, we can't"
-                                         " find the right database to fetch"
-                                         "infomation from.\nAre you sure you'"
-                                         "re usig the right server ?\nDid you"
-                                         "create a new database?")
+                                " find the right database to fetch"
+                                "infomation from.\nAre you sure you'"
+                                "re usig the right server ?\nDid you"
+                                "create a new database?")
+        else:
+          raise
       i = i + 1
       self.progress.setValue(i)
       if (i >= self.progress.maximum()):
@@ -78,7 +80,9 @@ class MatchFunctionAction(base.BoundFileAction):
       data = e.response()
       if "Invalid pk" in data['file'][0]:
         logger('match').error("Something wrong happened, we can't"
-                                       " find the right database to fetch info"
-                                       "rmation from.\nAre you sure you're usi"
-                                       "ng the right server ?\nDid you create "
-                                       "a new database?")
+                              " find the right database to fetch info"
+                              "rmation from.\nAre you sure you're usi"
+                              "ng the right server ?\nDid you create "
+                              "a new database?")
+      else:
+        raise

--- a/idaplugin/rematch/actions/match.py
+++ b/idaplugin/rematch/actions/match.py
@@ -38,7 +38,7 @@ class MatchAllAction(base.BoundFileAction):
         network.query("POST", "collab/instances/", params=func.serialize(),
                       json=True)
       except exceptions.QueryException as e:
-        data = e.data()
+        data = e.response()
         if "Invalid pk" in data['file'][0]:
           logger('MatchAllAction').error("Something wrong happened, we can't"
                                          " find the right database to fetch"
@@ -75,7 +75,7 @@ class MatchFunctionAction(base.BoundFileAction):
       network.query("POST", "collab/instances/", params=data.serialize(),
                     json=True)
     except exceptions.QueryException as e:
-      data = e.data()
+      data = e.response()
       if "Invalid pk" in data['file'][0]:
         logger('MatchAllAction').error("Something wrong happened, we can't"
                                        " find the right database to fetch info"

--- a/idaplugin/rematch/actions/match.py
+++ b/idaplugin/rematch/actions/match.py
@@ -40,11 +40,11 @@ class MatchAllAction(base.BoundFileAction):
       except exceptions.QueryException as e:
         data = e.response()
         if "Invalid pk" in data['file'][0]:
-          logger('MatchAllAction').error("Something wrong happened, we can't"
+          logger('match').error("Something wrong happened, we can't"
                                          " find the right database to fetch"
                                          "infomation from.\nAre you sure you'"
                                          "re usig the right server ?\nDid you"
-                                         "create a new database ?")
+                                         "create a new database?")
       i = i + 1
       self.progress.setValue(i)
       if (i >= self.progress.maximum()):
@@ -77,8 +77,8 @@ class MatchFunctionAction(base.BoundFileAction):
     except exceptions.QueryException as e:
       data = e.response()
       if "Invalid pk" in data['file'][0]:
-        logger('MatchAllAction').error("Something wrong happened, we can't"
+        logger('match').error("Something wrong happened, we can't"
                                        " find the right database to fetch info"
                                        "rmation from.\nAre you sure you're usi"
                                        "ng the right server ?\nDid you create "
-                                       "a new database ?")
+                                       "a new database?")

--- a/idaplugin/rematch/actions/project.py
+++ b/idaplugin/rematch/actions/project.py
@@ -24,10 +24,12 @@ class AddProjectAction(base.AuthAction):
       data = e.response()
       if "Invalid pk" in data['file'][0]:
         logger('project').error("Something wrong happened, we can't"
-                                       " find the right database to fetch"
-                                       "infomation from.\nAre you sure you'"
-                                       "re usig the right server ?\nDid you"
-                                       "create a new database?")
+                                " find the right database to fetch"
+                                "infomation from.\nAre you sure you'"
+                                "re usig the right server ?\nDid you"
+                                "create a new database?")
+      else:
+        raise
     return resp
 
 
@@ -53,10 +55,12 @@ class AddFileAction(base.UnboundFileAction):
       data = e.response()
       if "Invalid pk" in data['file'][0]:
         logger('project').error("Something wrong happened, we can't"
-                                       " find the right database to fetch"
-                                       "infomation from.\nAre you sure you'"
-                                       "re usig the right server ?\nDid you"
-                                       "create a new database?")
+                                " find the right database to fetch"
+                                "infomation from.\nAre you sure you'"
+                                "re usig the right server ?\nDid you"
+                                "create a new database?")
+      else:
+        raise
     return resp
 
   @staticmethod

--- a/idaplugin/rematch/actions/project.py
+++ b/idaplugin/rematch/actions/project.py
@@ -1,8 +1,7 @@
 from . import base
 from ..dialogs.project import AddProjectDialog, AddFileDialog
 
-from .. import netnode
-from .. import network
+from .. import netnode, network, logger, exceptions
 
 
 class AddProjectAction(base.AuthAction):
@@ -18,8 +17,18 @@ class AddProjectAction(base.AuthAction):
     if bind_current:
       data['files'].append(netnode.bound_file_id)
 
-    return network.QueryWorker("POST", "collab/projects/", params=data,
-                               json=True)
+    try:
+      resp = network.QueryWorker("POST", "collab/projects/", params=data,
+                                 json=True)
+    except exceptions.QueryException as e:
+      data = e.response()
+      if "Invalid pk" in data['file'][0]:
+        logger('MatchAllAction').error("Something wrong happened, we can't"
+                                       " find the right database to fetch"
+                                       "infomation from.\nAre you sure you'"
+                                       "re usig the right server ?\nDid you"
+                                       "create a new database ?")
+    return resp
 
 
 class AddFileAction(base.UnboundFileAction):
@@ -37,8 +46,18 @@ class AddFileAction(base.UnboundFileAction):
       # TODO: uploadfile
       pass
 
-    return network.QueryWorker("POST", "collab/files/", params=data,
-                               json=True)
+    try:
+      resp = network.QueryWorker("POST", "collab/files/", params=data,
+                                 json=True)
+    except exceptions.QueryException as e:
+      data = e.response()
+      if "Invalid pk" in data['file'][0]:
+        logger('MatchAllAction').error("Something wrong happened, we can't"
+                                       " find the right database to fetch"
+                                       "infomation from.\nAre you sure you'"
+                                       "re usig the right server ?\nDid you"
+                                       "create a new database ?")
+    return resp
 
   @staticmethod
   def response_handler(response):

--- a/idaplugin/rematch/actions/project.py
+++ b/idaplugin/rematch/actions/project.py
@@ -23,11 +23,11 @@ class AddProjectAction(base.AuthAction):
     except exceptions.QueryException as e:
       data = e.response()
       if "Invalid pk" in data['file'][0]:
-        logger('MatchAllAction').error("Something wrong happened, we can't"
+        logger('project').error("Something wrong happened, we can't"
                                        " find the right database to fetch"
                                        "infomation from.\nAre you sure you'"
                                        "re usig the right server ?\nDid you"
-                                       "create a new database ?")
+                                       "create a new database?")
     return resp
 
 
@@ -52,11 +52,11 @@ class AddFileAction(base.UnboundFileAction):
     except exceptions.QueryException as e:
       data = e.response()
       if "Invalid pk" in data['file'][0]:
-        logger('MatchAllAction').error("Something wrong happened, we can't"
+        logger('project').error("Something wrong happened, we can't"
                                        " find the right database to fetch"
                                        "infomation from.\nAre you sure you'"
                                        "re usig the right server ?\nDid you"
-                                       "create a new database ?")
+                                       "create a new database?")
     return resp
 
   @staticmethod

--- a/idaplugin/rematch/exceptions.py
+++ b/idaplugin/rematch/exceptions.py
@@ -3,13 +3,13 @@ class RematchException(Exception):
 
   def __init__(self, response=None, **kwargs):
     super(RematchException, self).__init__(**kwargs)
-    self.response = response
+    self._response = response
 
   def __str__(self):
-    return "<{}: {}, {}>".format(self.__class__, self.response, self.message)
+    return "<{}: {}, {}>".format(self.__class__, self._response, self.message)
 
-  def data(self):
-    return self.response
+  def response(self):
+    return self._response
 
 
 class UnsavedIdb(RematchException):

--- a/idaplugin/rematch/exceptions.py
+++ b/idaplugin/rematch/exceptions.py
@@ -8,6 +8,9 @@ class RematchException(Exception):
   def __str__(self):
     return "<{}: {}, {}>".format(self.__class__, self.response, self.message)
 
+  def data(self):
+    return self.response
+
 
 class UnsavedIdb(RematchException):
   message = ("You mast save the IDB before uploading it to the database, "


### PR DESCRIPTION
the idaplugin contains a netnode which saves the project id (pk) and tries to access it
if it's invalid, the server would return 400 we would faecpalm

This temp fix basically tries to see if we got "Invalid pk" from the server and warn the user
that the server may have been changed.
We should handle this better in future releases.

Unless there is something more straightforward and your review is OK, there is another place where the exception must take in project.py 
