### PR TITLE
remove allauth from server requirements and force rest-auth >= 0.8.2

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,5 +3,4 @@ numpy
 pygments
 django-registration-redux
 djangorestframework
-django-rest-auth
-django-allauth
+django-rest-auth >= 0.8.2


### PR DESCRIPTION
rest-auth had a bug that made allauth an implicit requirement and not an optional one, it was fixed in 0.8.2

Signed-off-by: Nir Izraeli <nirizr@gmail.com>