### PR TITLE
Add web api list view filters

### DIFF
--- a/server/collab/serializers.py
+++ b/server/collab/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from collab.models import Project, File, Task, Instance, Vector
+from collab.models import Project, File, Task, Instance, Vector, Match
 
 
 class ProjectSerializer(serializers.ModelSerializer):
@@ -74,3 +74,9 @@ class VectorSerializer(serializers.ModelSerializer):
   class Meta:
     model = Vector
     fields = ('id', 'file', 'instance', 'type', 'type_version', 'data')
+
+
+class MatchSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = Match
+    fields = ('task', 'type', 'score')

--- a/server/rematch/settings.py
+++ b/server/rematch/settings.py
@@ -94,7 +94,11 @@ REST_FRAMEWORK = {
     'rest_framework.authentication.BasicAuthentication',
     'rest_framework.authentication.TokenAuthentication',
     'rest_framework.authentication.SessionAuthentication',
-  )
+  ),
+
+  'DEFAULT_FILTER_BACKENDS': (
+    'django_filters.rest_framework.DjangoFilterBackend',
+  ),
 }
 
 REST_SESSION_LOGIN = False


### PR DESCRIPTION
Both the rest and browsable API interfaces will now allow filtering results by model fields using url query parameters.

Also, for completeness's sake add Match view and serializer.

This is required by #17 but could benefit other issues and is simple enough to get merged before Results Dialog is ready.

Signed-off-by: Nir Izraeli <nirizr@gmail.com>