### PR TITLE
Replace non-existing Django ORM .filter(__not) with .exclude()

### DIFF
--- a/server/collab/tasks.py
+++ b/server/collab/tasks.py
@@ -29,12 +29,13 @@ def match():
       source_filter['instance__offset__lte'] = source_end
     base_source_vectors = Vector.objects.filter(**source_filter)
 
-    target_filter = {'file_id__not': source_file}
+    target_filter = {}
     if target_project:
       target_filter = {'file__project_id': target_project}
     elif target_file:
       target_filter = {'file_id': target_file}
     base_target_vectors = Vector.objects.filter(**target_filter)
+    base_target_vectors = base_target_vectors.exclude(file_id=source_file)
 
     print("Running task {}".format(match.request.id))
     # TODO: order might be important here


### PR DESCRIPTION
I used django's ORM filters to filter file_id with the not modifier,
but there's no such modifier at all so I negated the condition.
Instead of filter(file_id != N) I changed it to exclude(file_id == N).

Signed-off-by: Nir Izraeli <nirizr@gmail.com>