### PR TITLE
Fix score result for histogram matches and only add to database match…

### DIFF
--- a/server/collab/matches/hist_match.py
+++ b/server/collab/matches/hist_match.py
@@ -34,6 +34,6 @@ class HistogramMatch(match.Match):
         target_id = target_ids[target_i]
         target_instance_id = target_instance_ids[target_i]
 
-        score = np.linalg.norm(source_vector - target_vector)
+        score = (1 - np.linalg.norm(source_vector - target_vector)) * 100
         yield (source_id, source_instance_id, target_id, target_instance_id,
                score)


### PR DESCRIPTION
…es that at least 50%

This should reduce the db size significantly and speed up some things

Signed-off-by: Nir Izraeli <nirizr@gmail.com>