### PR TITLE
Guy/fix requirements and celery

### DIFF
--- a/server/rematch/celery.py
+++ b/server/rematch/celery.py
@@ -3,12 +3,14 @@ from __future__ import absolute_import
 import os
 
 from celery import Celery
+import django
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'rematch.settings')
+django.setup()
+
 
 from django.conf import settings  # noqa
-
 app = Celery('rematch')
 
 # Using a string here means the worker will not have to


### PR DESCRIPTION
my pip configuration didn't work without those changes, this is from a fresh debian install

> deb@debian:~/rematch$ pip freeze
> Django==1.10.3
> Pillow==2.6.1
> PyYAML==3.11
> Pygments==2.0.1
> SOAPpy==0.12.22
> amqp==1.4.9
> anyjson==0.3.3
> argparse==1.2.1
> billiard==3.3.0.23
> celery==3.1.13
> cffi==0.8.6
> chardet==2.3.0
> colorama==0.3.2
> cryptography==0.6.1
> decorator==3.4.0
> defusedxml==0.4.1
> django-allauth==0.28.0
> django-celery==3.1.17
> django-filter==0.15.3
> django-registration-redux==1.4
> django-rest-auth==0.8.2
> djangorestframework==3.5.3
> docutils==0.12
> flake8==2.2.2
> hiredis==0.1.4
> html5lib==0.999
> joblib==0.8.3
> kombu==3.0.37
> mailer==0.7
> matplotlib==1.4.2
> mccabe==0.2.1
> mock==1.0.1
> ndg-httpsclient==0.3.2
> nose==1.3.4
> numpy==1.11.2
> oauthlib==2.0.0
> pep8==1.5.7
> ply==3.4
> pyOpenSSL==0.14
> pyasn1==0.1.7
> pycparser==2.10
> pyflakes==0.8.1
> pyparsing==2.0.3
> python-apt==0.9.3.12
> python-dateutil==2.2
> python-debian==0.1.27
> python-debianbts==1.11
> python-memcached==1.53
> python-openid==2.2.5
> pytz==2012c
> redis==2.10.1
> reportbug==6.6.3
> requests==2.4.3
> requests-oauthlib==0.7.0
> roman==2.0.0
> scikit-learn==0.14.1
> scipy==0.14.0
> simplejson==3.6.5
> six==1.10.0
> urllib3==1.9.1
> vine==1.1.3
> wheel==0.24.0
> wsgiref==0.1.2
> wstools==0.4.3
> 