### PR TITLE
Refuse using celery 4 because django-celery doesn't support it yet

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,5 +6,5 @@ django-registration-redux
 djangorestframework
 django-rest-auth
 django-allauth
-celery
+celery<4.0
 django-celery


### PR DESCRIPTION
Signed-off-by: Nir Izraeli <nirizr@gmail.com>