### PR TITLE
Fix network logger call bug

### DIFF
--- a/idaplugin/rematch/network.py
+++ b/idaplugin/rematch/network.py
@@ -104,7 +104,7 @@ def query(method, url, server=None, token=None, params=None, json=False):
     return return_obj
   except Exception as ex:
     import traceback
-    logger.network('network').error(traceback.format_exc())
+    logger('network').error(traceback.format_exc())
     rematch_ex = exceptions.factory(ex)
     logger('network').debug(rematch_ex)
     raise rematch_ex
@@ -124,7 +124,7 @@ def get_server(server):
      server = server + "/"
   except Exception:
     import traceback
-    logger.network('network').error(traceback.format_exc())
+    logger('network').error(traceback.format_exc())
   return server
 
 


### PR DESCRIPTION
Erroneously calls `logger.network('network')` instead of `logger('network')`

Signed-off-by: Nir Izraeli <nirizr@gmail.com>