### PR TITLE
Improve matching performance and fix database died errors

### DIFF
--- a/server/collab/matches/hist_match.py
+++ b/server/collab/matches/hist_match.py
@@ -28,27 +28,25 @@ class HistogramMatch(match.Match):
     source_list = [json.loads(d) for d in source_data]
     target_list = [json.loads(d) for d in target_data]
     print("load time: {}".format(time.time() - start))
-    print(source_list[:5])
-    print(target_list[:5])
+    print("Source input sample:\t{}".format(source_list[:5]))
+    print("Source input sample:\t{}".format(target_list[:5]))
 
     dictvect = skl.feature_extraction.DictVectorizer()
     source_matrix = dictvect.fit_transform(source_list)
     target_matrix = dictvect.transform(target_list)
     print("vectorization time: {}".format(time.time() - start))
-    print(source_matrix.shape)
-    print(target_matrix.shape)
+    print("source matrix: {}, target matrix: {}".format(source_matrix.shape,
+                                                        target_matrix.shape))
 
     source_matrix = skl.preprocessing.normalize(source_matrix, norm='l2')
     target_matrix = skl.preprocessing.normalize(target_matrix, norm='l2')
     print("norm time: {}".format(time.time() - start))
-    print(type(source_matrix))
-    print(type(target_matrix))
 
     distance_matrix = skl.metrics.pairwise.euclidean_distances(source_matrix,
                                                                target_matrix)
     print("distance time: {}".format(time.time() - start))
-    print("min distance: {}".format(distance_matrix.min()))
-    print("max distance: {}".format(distance_matrix.max()))
+    print("min distance: {}, max distance: {}".format(distance_matrix.min(),
+                                                      distance_matrix.max()))
 
     for source_i, target_i in np.ndindex(*distance_matrix.shape):
       source_id = source_ids[source_i]

--- a/server/collab/matches/hist_match.py
+++ b/server/collab/matches/hist_match.py
@@ -1,8 +1,8 @@
 import itertools
 import json
 
-import numpy as np
 import sklearn as skl
+import sklearn.metrics  # noqa flake8 importing as a different name
 import sklearn.preprocessing  # noqa flake8 importing as a different name
 import sklearn.feature_extraction  # noqa flake8 importing as a different name
 
@@ -19,21 +19,26 @@ class HistogramMatch(match.Match):
 
     source_ids, source_instance_ids, source_data = source_values
     target_ids, target_instance_ids, target_data = target_values
+
     dictvect = skl.feature_extraction.DictVectorizer()
     source_data = dictvect.fit_transform([json.loads(d) for d in source_data])
     target_data = dictvect.transform([json.loads(d) for d in target_data])
+
     source_matrix = skl.preprocessing.normalize(source_data, axis=1, norm='l1')
     target_matrix = skl.preprocessing.normalize(target_data, axis=1, norm='l1')
-    for source_i in range(source_matrix.shape[0]):
-      source_vector = source_matrix[source_i].toarray()
+
+    distance_matrix = skl.metrics.pairwise.pairwise_distances(source_matrix,
+                                                              target_matrix)
+
+    for source_i in range(distance_matrix.shape[0]):
       source_id = source_ids[source_i]
       source_instance_id = source_instance_ids[source_i]
 
-      for target_i in range(target_matrix.shape[0]):
-        target_vector = target_matrix[target_i].toarray()
+      for target_i in range(distance_matrix.shape[1]):
         target_id = target_ids[target_i]
         target_instance_id = target_instance_ids[target_i]
 
-        score = (1 - np.linalg.norm(source_vector - target_vector)) * 100
+        distance = distance_matrix[source_i][target_i]
+        score = (1 - distance) * 100
         yield (source_id, source_instance_id, target_id, target_instance_id,
                score)

--- a/server/collab/matches/hist_match.py
+++ b/server/collab/matches/hist_match.py
@@ -2,6 +2,7 @@ import itertools
 import json
 import time
 
+import numpy as np
 import sklearn as skl
 import sklearn.metrics  # noqa flake8 importing as a different name
 import sklearn.preprocessing  # noqa flake8 importing as a different name
@@ -46,8 +47,10 @@ class HistogramMatch(match.Match):
     distance_matrix = skl.metrics.pairwise.euclidean_distances(source_matrix,
                                                                target_matrix)
     print("distance time: {}".format(time.time() - start))
+    print("min distance: {}".format(distance_matrix.min()))
+    print("max distance: {}".format(distance_matrix.max()))
 
-    for source_i, target_i in itertools.izip(*(distance_matrix<0.5).nonzero()):
+    for source_i, target_i in np.ndindex(*distance_matrix.shape):
       source_id = source_ids[source_i]
       source_instance_id = source_instance_ids[source_i]
 

--- a/server/collab/tasks.py
+++ b/server/collab/tasks.py
@@ -51,7 +51,7 @@ def match(task_id):
       if source_vectors.count() and target_vectors.count():
         match_objs = gen_match_objs(task_id, match_type, source_vectors,
                                     target_vectors)
-        Match.objects.bulk_create(match_objs)
+        Match.objects.bulk_create(match_objs, batch_size=10000)
       print("\tTook: {}".format(now() - start))
 
       task.update(progress=F('progress') + 1)


### PR DESCRIPTION
By limiting bulk creation sizes to avoid extremely long SQL queries
and replacing manual one by one distance calculation with a call to
`skl.metrics.pairwise.pairwise_distances`.

Signed-off-by: Nir Izraeli <nirizr@gmail.com>