### PR TITLE
Dont hide created date in file version

### DIFF
--- a/idaplugin/rematch/actions/match.py
+++ b/idaplugin/rematch/actions/match.py
@@ -61,7 +61,7 @@ class MatchAction(base.BoundFileAction):
   def response_handler(self, file_version):
     self.file_version_id = file_version['id']
 
-    if file_version['created']:
+    if file_version['newly_created']:
       self.start_upload()
     else:
       self.start_task()

--- a/server/collab/views.py
+++ b/server/collab/views.py
@@ -60,7 +60,7 @@ class FileViewSet(ViewSetOwnerMixin, viewsets.ModelViewSet):
 
     resp_status = status.HTTP_201_CREATED if created else status.HTTP_200_OK
     response_data = serializer.data
-    response_data['created'] = created
+    response_data['newly_created'] = created
     return response.Response(response_data, status=resp_status)
 
 


### PR DESCRIPTION
use 'newly_created' for the boolean distinction between new version_file and an existing one

Signed-off-by: Nir Izraeli <nirizr@gmail.com>