### PR TITLE
Clean up dummy vector, non existant opcode hist match

### DIFF
--- a/idaplugin/rematch/collectors/dummy.py
+++ b/idaplugin/rematch/collectors/dummy.py
@@ -1,7 +1,0 @@
-from .vector import Vector
-
-
-class DummyVector(Vector):
-  type = 'dummy'
-  type_version = 0
-  data = 'dummydata'

--- a/idaplugin/rematch/instances/function.py
+++ b/idaplugin/rematch/instances/function.py
@@ -7,7 +7,6 @@ class EmptyFunctionInstance(base.BaseInstance):
 
   def __init__(self, *args, **kwargs):
     super(EmptyFunctionInstance, self).__init__(*args, **kwargs)
-    # self.vectors.add(collectors.name_hash)
 
 
 class FunctionInstance(EmptyFunctionInstance):
@@ -18,5 +17,3 @@ class FunctionInstance(EmptyFunctionInstance):
     self.vectors.add(collectors.AssemblyHashVector)
     self.vectors.add(collectors.MnemonicHashVector)
     self.vectors.add(collectors.MnemonicHistVector)
-    # self.vectors.add(collectors.data_hash)
-    # self.vectors.add(collectors.opcode_hash)

--- a/server/collab/matches/__init__.py
+++ b/server/collab/matches/__init__.py
@@ -1,11 +1,9 @@
 from .assembly_hash import AssemblyHashMatch
 from .mnemonic_hash import MnemonicHashMatch
 from .mnemonic_hist import MnemonicHistogramMatch
-from .opcode_hist import OpcodeHistogramMatch
 
 
-match_list = [AssemblyHashMatch, MnemonicHashMatch, MnemonicHistogramMatch,
-              OpcodeHistogramMatch]
+match_list = [AssemblyHashMatch, MnemonicHashMatch, MnemonicHistogramMatch]
 
 __all__ = ['AssemblyHashMatch', 'MnemonicHashMatch', 'MnemonicHistogramMatch',
-           'OpcodeHistogramMatch', 'match_list']
+           'match_list']

--- a/server/collab/matches/opcode_hist.py
+++ b/server/collab/matches/opcode_hist.py
@@ -1,6 +1,0 @@
-from . import hist_match
-
-
-class OpcodeHistogramMatch(hist_match.HistogramMatch):
-  vector_type = 'opcode_histogram'
-  match_type = 'opcode_histogram'

--- a/server/collab/models.py
+++ b/server/collab/models.py
@@ -75,18 +75,12 @@ class Instance(models.Model):
 
 
 class Vector(models.Model):
-  DUMMY = 'dummy'
-  TYPE_HASH = 'hash'
   TYPE_ASSEMBLY_HASH = 'assembly_hash'
   TYPE_MNEMONIC_HASH = 'mnemonic_hash'
   TYPE_MNEMONIC_HIST = 'mnemonic_hist'
-  TYPE_OPCODE_HIST = 'opcode_histogram'
-  TYPE_CHOICES = ((DUMMY, "Dummy"),
-                  (TYPE_HASH, "Hash"),
-                  (TYPE_ASSEMBLY_HASH, "Assembly Hash"),
+  TYPE_CHOICES = [(TYPE_ASSEMBLY_HASH, "Assembly Hash"),
                   (TYPE_MNEMONIC_HASH, "Mnemonic Hash"),
-                  (TYPE_MNEMONIC_HIST, "Mnemonic Hist"),
-                  (TYPE_OPCODE_HIST, "Opcode Histogram"))
+                  (TYPE_MNEMONIC_HIST, "Mnemonic Hist")]
 
   instance = models.ForeignKey(Instance, related_name='vectors')
   file = models.ForeignKey(File, related_name='vectors')

--- a/tests/server/collab/test_all.py
+++ b/tests/server/collab/test_all.py
@@ -21,7 +21,7 @@ collab_models = {'projects': {'name': 'test_project_1', 'private': False,
                  'file_versions': {'md5hash': 'J' * 32},
                  'tasks': {},
                  'instances': {'offset': 0, 'type': 'function', 'vectors': []},
-                 'vectors': {'type': 'hash', 'type_version': 0,
+                 'vectors': {'type': 'assembly_hash', 'type_version': 0,
                              'data': 'data'}}
 
 collab_model_objects = {'projects': partial(Project, private=False),
@@ -30,8 +30,8 @@ collab_model_objects = {'projects': partial(Project, private=False),
                         'file_versions': partial(FileVersion),
                         'tasks': Task,
                         'instances': partial(Instance, offset=0),
-                        'vectors': partial(Vector, type='hash', data='data',
-                                           type_version=0),
+                        'vectors': partial(Vector, type='assembly_hash',
+                                           data='data', type_version=0),
                         'rand_hash': partial(rand_hash, 32)}
 
 collab_model_reqs = {'projects': {},


### PR DESCRIPTION
Turns out there were some leftover commented out code, a match that had no data to it (OpcodeHist), two unused vector types (dummy, hash) and one dummy collector. It's about time to remove all of those

Signed-off-by: Nir Izraeli <nirizr@gmail.com>