### PR TITLE
Fix string data extra quotes

### DIFF
--- a/idaplugin/rematch/collectors/__init__.py
+++ b/idaplugin/rematch/collectors/__init__.py
@@ -1,5 +1,5 @@
+from .collector import Collector
 from .vector import Vector
-from .dummy import DummyVector
 from .assembly_hash import AssemblyHashVector
 from .mnemonic_hash import MnemonicHashVector
 from .mnemonic_hist import MnemonicHistVector
@@ -15,6 +15,5 @@ def collect(offset, collectors):
       yield c.serialize()
 
 
-__all__ = [collect, Vector, DummyVector, AssemblyHashVector,
-           MnemonicHashVector, MnemonicHistVector, Annotation, NameAnnotation,
-           AssemblyAnnotation]
+__all__ = [collect, Collector, Vector, AssemblyHashVector, MnemonicHashVector,
+           MnemonicHistVector, Annotation, NameAnnotation, AssemblyAnnotation]

--- a/idaplugin/rematch/collectors/annotation.py
+++ b/idaplugin/rematch/collectors/annotation.py
@@ -1,15 +1,6 @@
-import json
+from . import collector
 
 
-class Annotation:
-  def __init__(self, offset, instance_id=None):
-    self.instance_id = instance_id
-    self.offset = offset
-
-  @staticmethod
-  def include():
-    return True
-
+class Annotation(collector.Collector):
   def serialize(self):
-    return {"instance": self.instance_id, "type": self.type,
-            "data": json.dumps(self.data)}
+    return {"instance": self.instance_id, "type": self.type, "data": self.data}

--- a/idaplugin/rematch/collectors/assembly_annotation.py
+++ b/idaplugin/rematch/collectors/assembly_annotation.py
@@ -7,8 +7,7 @@ from .annotation import Annotation
 class AssemblyAnnotation(Annotation):
   type = 'assembly'
 
-  @property
-  def data(self):
+  def _data(self):
     flow_chart = idaapi.FlowChart(idaapi.get_func(self.offset))
 
     nodes = {}

--- a/idaplugin/rematch/collectors/assembly_hash.py
+++ b/idaplugin/rematch/collectors/assembly_hash.py
@@ -10,8 +10,7 @@ class AssemblyHashVector(Vector):
   type = 'assembly_hash'
   type_version = 0
 
-  @property
-  def data(self):
+  def _data(self):
     md5 = hashlib.md5()
     for offset in idautils.FuncItems(self.offset):
       asm_line = idc.GetDisasmEx(offset, idc.GENDSM_MULTI_LINE)

--- a/idaplugin/rematch/collectors/collector.py
+++ b/idaplugin/rematch/collectors/collector.py
@@ -1,0 +1,24 @@
+import json
+
+
+try:
+  strtypes = (str, unicode)  # noqa
+except NameError:
+  strtypes = (str,)
+
+
+class Collector:
+  def __init__(self, offset, instance_id=None):
+    self.instance_id = instance_id
+    self.offset = offset
+    self.data = self.serialized_data()
+
+  @staticmethod
+  def include():
+    return True
+
+  def serialized_data(self):
+    data = self._data()
+    if not isinstance(data, strtypes):
+      data = json.dumps(data)
+    return data

--- a/idaplugin/rematch/collectors/mnemonic_hash.py
+++ b/idaplugin/rematch/collectors/mnemonic_hash.py
@@ -10,8 +10,7 @@ class MnemonicHashVector(Vector):
   type = 'mnemonic_hash'
   type_version = 0
 
-  @property
-  def data(self):
+  def _data(self):
     md5 = hashlib.md5()
     for offset in idautils.FuncItems(self.offset):
       mnem_line = idc.GetMnem(offset)

--- a/idaplugin/rematch/collectors/mnemonic_hist.py
+++ b/idaplugin/rematch/collectors/mnemonic_hist.py
@@ -10,8 +10,7 @@ class MnemonicHistVector(Vector):
   type = 'mnemonic_hist'
   type_version = 0
 
-  @property
-  def data(self):
+  def _data(self):
     instruction_hist = defaultdict(int)
 
     for offset in idautils.FuncItems(self.offset):

--- a/idaplugin/rematch/collectors/name_annotation.py
+++ b/idaplugin/rematch/collectors/name_annotation.py
@@ -10,6 +10,5 @@ class NameAnnotation(Annotation):
     f = idc.GetFlags(self.offset)
     return idc.hasUserName(f)
 
-  @property
-  def data(self):
+  def _data(self):
     return idc.Name(self.offset)

--- a/idaplugin/rematch/collectors/vector.py
+++ b/idaplugin/rematch/collectors/vector.py
@@ -1,15 +1,7 @@
-import json
+from . import collector
 
 
-class Vector:
-  def __init__(self, offset, instance_id=None):
-    self.instance_id = instance_id
-    self.offset = offset
-
-  @staticmethod
-  def include():
-    return True
-
+class Vector(collector.Collector):
   def serialize(self):
     return {"instance": self.instance_id, "type": self.type,
-            "type_version": self.type_version, "data": json.dumps(self.data)}
+            "type_version": self.type_version, "data": self.data}


### PR DESCRIPTION
json.dumps was adding unnecessary quotes around data objects of type string. This fix avoids the extra serialization in case data is a string object

Signed-off-by: Nir Izraeli <nirizr@gmail.com>