### PR TITLE
Add collab app config to set user friendly name

### DIFF
--- a/server/collab/__init__.py
+++ b/server/collab/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'collab.apps.Config'

--- a/server/collab/apps.py
+++ b/server/collab/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+  name = 'collab'
+  verbose_name = "Rematch"


### PR DESCRIPTION
verbose_name will be shown instead of "collab" in admin panels and other django
related interfaces as the name of the application.

Signed-off-by: Nir Izraeli <nirizr@gmail.com>