### PR TITLE
Implement matchers selection capability

### DIFF
--- a/idaplugin/rematch/actions/match.py
+++ b/idaplugin/rematch/actions/match.py
@@ -9,6 +9,7 @@ from .. import network, netnode, log
 from . import base
 
 import hashlib
+import json
 
 
 class MatchAction(base.BoundFileAction):
@@ -29,7 +30,7 @@ class MatchAction(base.BoundFileAction):
     self.target = None
     self.target_project = None
     self.target_file = None
-    self.methods = None
+    self.matchers = None
 
     self.delayed_queries = []
 
@@ -75,14 +76,14 @@ class MatchAction(base.BoundFileAction):
     return version_hash
 
   def submit_handler(self, source, source_single, source_range, target,
-                     target_project, target_file, methods):
+                     target_project, target_file, matchers):
     self.source = source
     self.source_single = source_single
     self.source_range = source_range
     self.target = target
     self.target_project = target_project if target == 'project' else None
     self.target_file = target_file if target == 'file' else None
-    self.methods = methods
+    self.matchers = matchers
 
     file_version_hash = self.calc_file_version_hash()
     uri = "collab/files/{}/file_version/{}/".format(netnode.bound_file_id,
@@ -168,7 +169,7 @@ class MatchAction(base.BoundFileAction):
               'source_end': self.source_range[1],
               'target_project': self.target_project,
               'target_file': self.target_file,
-              'source': self.source, 'methods': self.methods}
+              'source': self.source, 'matchers': json.dumps(self.matchers)}
     r = network.query("POST", "collab/tasks/", params=params, json=True)
     self.task_id = r['id']
 

--- a/idaplugin/rematch/dialogs/base.py
+++ b/idaplugin/rematch/dialogs/base.py
@@ -145,6 +145,41 @@ class QItemSelect(QtWidgets.QComboBox):
       self.setEnabled(False)
 
 
+class QItemCheckBoxes(QtWidgets.QGridLayout):
+  def __init__(self, item, name_field='name', id_field='id', exclude=None,
+               columns=3):
+    super(QItemCheckBoxes, self).__init__()
+    self.item = item
+    self.name_field = name_field
+    self.id_field = id_field
+    self.exclude = exclude
+    self.columns = columns
+    self.checkboxes = []
+
+    self.refresh()
+
+  def refresh(self):
+    response = network.query("GET", "collab/{}/".format(self.item), json=True)
+
+    self.checkboxes = []
+    for i, obj in enumerate(response):
+      item_name = obj[self.name_field]
+      item_id = obj[self.id_field]
+
+      if self.exclude and (item_name in self.exclude or
+                           item_id in self.exclude):
+        continue
+
+      checkbox_widget = QtWidgets.QCheckBox(item_name)
+      checkbox_widget.id = item_id
+      checkbox_widget.setChecked(True)
+      self.addWidget(checkbox_widget, i / self.columns, i % self.columns)
+      self.checkboxes.append(checkbox_widget)
+
+  def get_result(self):
+    return [cb.id for cb in self.checkboxes if cb.isChecked()]
+
+
 class QRadioGroup(QtWidgets.QGroupBox):
   def __init__(self, title, *radios, **kwargs):
     checked = kwargs.pop('checked', None)

--- a/idaplugin/rematch/dialogs/match.py
+++ b/idaplugin/rematch/dialogs/match.py
@@ -31,36 +31,17 @@ class MatchDialog(base.BaseDialog):
     self.targetGrp = base.QRadioGroup("Match target", *choices)
     self.base_layout.addWidget(self.targetGrp)
 
-    self.identity = QtWidgets.QCheckBox("Identify matches")
-    self.fuzzy = QtWidgets.QCheckBox("Fuzzy matches")
-    self.graph = QtWidgets.QCheckBox("Graph matches")
-    self.identity.setChecked(True)
-    self.fuzzy.setChecked(True)
-    self.graph.setChecked(True)
-    method_lyt = QtWidgets.QVBoxLayout()
-    method_lyt.addWidget(self.identity)
-    method_lyt.addWidget(self.fuzzy)
-    method_lyt.addWidget(self.graph)
+    self.matchers = base.QItemCheckBoxes(item='matches/matchers',
+                                         name_field='matcher_name',
+                                         id_field='match_type')
 
     method_gbx = QtWidgets.QGroupBox("Match methods")
-    method_gbx.setDisabled(True)
-    method_gbx.setToolTip("Match method control functionality is not "
-                          "currently supported. Plese express your need of "
-                          "this functionality at our github.")
-    method_gbx.setLayout(method_lyt)
+    method_gbx.setLayout(self.matchers)
     self.base_layout.addWidget(method_gbx)
 
     self.bottom_layout("&Start matching")
 
   def data(self):
-    methods = []
-    if self.identity.isChecked():
-      methods.append('identity')
-    if self.fuzzy.isChecked():
-      methods.append('fuzzy')
-    if self.graph.isChecked():
-      methods.append('graph')
-
     return {'source': self.sourceGrp.get_result(),
             'source_single': self.source_single.func.startEA
                                if self.source_single.func else None,
@@ -71,4 +52,4 @@ class MatchDialog(base.BaseDialog):
             'target': self.targetGrp.get_result(),
             'target_project': self.target_project.currentData(),
             'target_file': self.target_file.currentData(),
-            'methods': methods}
+            'matchers': self.matchers.get_result()}

--- a/server/collab/matchers/assembly_hash.py
+++ b/server/collab/matchers/assembly_hash.py
@@ -4,3 +4,4 @@ from . import hash_matcher
 class AssemblyHashMatcher(hash_matcher.HashMatcher):
   vector_type = 'assembly_hash'
   match_type = 'assembly_hash'
+  matcher_name = "Assembly Hash"

--- a/server/collab/matchers/mnemonic_hash.py
+++ b/server/collab/matchers/mnemonic_hash.py
@@ -4,3 +4,4 @@ from . import hash_matcher
 class MnemonicHashMatcher(hash_matcher.HashMatcher):
   vector_type = 'mnemonic_hash'
   match_type = 'mnemonic_hash'
+  matcher_name = "Mnemonic Hash"

--- a/server/collab/matchers/mnemonic_hist.py
+++ b/server/collab/matchers/mnemonic_hist.py
@@ -4,3 +4,4 @@ from . import hist_matcher
 class MnemonicHistogramMatcher(hist_matcher.HistogramMatcher):
   vector_type = 'mnemonic_hist'
   match_type = 'mnemonic_hist'
+  matcher_name = "Mnemonic Histogram"

--- a/server/collab/matchers/name_hash.py
+++ b/server/collab/matchers/name_hash.py
@@ -4,3 +4,4 @@ from . import hash_matcher
 class NameHashMatcher(hash_matcher.HashMatcher):
   vector_type = 'name_hash'
   match_type = 'name_hash'
+  matcher_name = "Name Hash"

--- a/server/collab/models.py
+++ b/server/collab/models.py
@@ -127,6 +127,7 @@ class Task(models.Model):
   # TODO: make sure only at least one of target_file/target_project is null
   target_file = models.ForeignKey(File, null=True)
   target_project = models.ForeignKey(Project, null=True)
+  matchers = models.TextField(default='[]')
 
   progress = models.PositiveSmallIntegerField(default=0)
   progress_max = models.PositiveSmallIntegerField(null=True)

--- a/server/collab/serializers.py
+++ b/server/collab/serializers.py
@@ -43,8 +43,8 @@ class TaskSerializer(serializers.ModelSerializer):
     model = Task
     fields = ('id', 'task_id', 'created', 'finished', 'owner', 'status',
               'target_project', 'target_file', 'source_file',
-              'source_file_version', 'source_start', 'source_end', 'progress',
-              'progress_max')
+              'source_file_version', 'source_start', 'source_end', 'matchers',
+              'progress', 'progress_max')
 
 
 class TaskEditSerializer(TaskSerializer):
@@ -54,6 +54,7 @@ class TaskEditSerializer(TaskSerializer):
   source_file_version = serializers.ReadOnlyField()
   source_start = serializers.ReadOnlyField()
   source_end = serializers.ReadOnlyField()
+  matchers = serializers.ReadOnlyField()
 
 
 class SimpleInstanceSerializer(serializers.ModelSerializer):

--- a/server/collab/serializers.py
+++ b/server/collab/serializers.py
@@ -135,3 +135,9 @@ class MatchSerializer(serializers.ModelSerializer):
   class Meta:
     model = Match
     fields = ('from_instance', 'to_instance', 'task', 'type', 'score')
+
+
+class MatcherSerializer(serializers.Serializer):
+  match_type = serializers.ReadOnlyField()
+  vector_type = serializers.ReadOnlyField()
+  matcher_name = serializers.ReadOnlyField()

--- a/server/collab/tasks.py
+++ b/server/collab/tasks.py
@@ -5,24 +5,29 @@ from collab import matchers
 
 from celery import shared_task
 
+import json
+
 
 @shared_task
 def match(task_id):
   try:
-    # recording the task has started
     task = Task.objects.filter(id=task_id)
-    task.update(status=Task.STATUS_STARTED, progress=0,
-                progress_max=len(matchers.matchers_list),
-                task_id=match.request.id)
 
     # get input parameters
     task_values = task.values_list('id', 'source_file_version__file_id',
                                    'source_start', 'source_end',
                                    'source_file_version_id',
-                                   'target_project_id', 'target_file_id').get()
+                                   'target_project_id', 'target_file_id',
+                                   'matchers').get()
     print(task_values)
     (task_id, source_file, source_start, source_end, source_file_version,
-     target_project, target_file) = task_values
+     target_project, target_file, requested_matchers) = task_values
+
+    requested_matchers = set(json.loads(requested_matchers))
+
+    # recording the task has started
+    task.update(status=Task.STATUS_STARTED, progress=0,
+                progress_max=len(requested_matchers), task_id=match.request.id)
 
     source_filter = {'file_id': source_file,
                      'file_version_id': source_file_version}
@@ -43,6 +48,10 @@ def match(task_id):
     print("Running task {}".format(match.request.id))
     # TODO: order might be important here
     for matcher in matchers.matchers_list:
+      if matcher.match_type not in requested_matchers:
+        continue
+      requested_matchers.remove(matcher.match_type)
+
       start = now()
       source_vectors = base_source_vectors.filter(type=matcher.vector_type)
       target_vectors = base_target_vectors.filter(type=matcher.vector_type)
@@ -56,9 +65,16 @@ def match(task_id):
               "{} matches".format(source_count, target_count, matcher,
                                   len(match_objs)))
         Match.objects.bulk_create(match_objs, batch_size=10000)
+      else:
+        print("Skipped matcher {} with {} local vectors and {} remote vectors"
+              "".format(matcher, source_count, target_count))
       print("\tTook: {}".format(now() - start))
 
       task.update(progress=F('progress') + 1)
+
+    if requested_matchers:
+      msg = "Unfamiliar matchers were requested: {}".format(requested_matchers)
+      raise ValueError(msg)
   except Exception:
     task.update(status=Task.STATUS_FAILED, finished=now())
     raise

--- a/server/collab/views.py
+++ b/server/collab/views.py
@@ -6,9 +6,11 @@ from collab.serializers import (ProjectSerializer, FileSerializer,
                                 FileVersionSerializer, TaskSerializer,
                                 TaskEditSerializer, InstanceVectorSerializer,
                                 VectorSerializer, MatchSerializer,
-                                SimpleInstanceSerializer, AnnotationSerializer)
+                                SimpleInstanceSerializer, AnnotationSerializer,
+                                MatcherSerializer)
 from collab.permissions import IsOwnerOrReadOnly
 from collab import tasks
+from collab.matchers import matchers_list
 
 
 class ViewSetOwnerMixin(object):
@@ -153,6 +155,13 @@ class MatchViewSet(viewsets.ReadOnlyModelViewSet):
   queryset = Match.objects.all()
   serializer_class = MatchSerializer
   filter_fields = ('task', 'type', 'score')
+
+  @staticmethod
+  @decorators.list_route()
+  def matchers(request):
+    del request
+    serializer = MatcherSerializer(matchers_list, many=True)
+    return response.Response(serializer.data)
 
 
 class InstanceViewSet(ViewSetManyAllowedMixin, ViewSetOwnerMixin,

--- a/tests/server/collab/test_all.py
+++ b/tests/server/collab/test_all.py
@@ -4,8 +4,10 @@ from rest_framework import status, test
 
 from django.db import models
 from collab.models import Project, File, FileVersion, Task, Instance, Vector
+from collab.matchers import matchers_list
 
 import random
+import json
 
 
 @pytest.fixture
@@ -24,6 +26,8 @@ def rand_hash(n):
   return ''.join(random.choice("01234567890ABCDEF") for _ in range(n))
 
 
+requested_matchers = json.dumps([m.match_type for m in matchers_list])
+
 collab_models = {'projects': {'name': 'test_project_1', 'private': False,
                               'description': 'description_1', 'files': []},
                  'files': {'md5hash': 'H' * 32, 'name': 'file1',
@@ -39,7 +43,7 @@ collab_model_objects = {'projects': partial(Project, private=False),
                         'files': partial(File, name='name', description='desc',
                                          md5hash='H' * 32),
                         'file_versions': partial(FileVersion),
-                        'tasks': Task,
+                        'tasks': partial(Task, matchers=requested_matchers),
                         'instances': partial(Instance, offset=0),
                         'vectors': partial(Vector, type='assembly_hash',
                                            data='data', type_version=0),

--- a/tests/server/collab/test_all.py
+++ b/tests/server/collab/test_all.py
@@ -214,3 +214,9 @@ def test_task(admin_user):
 
   from collab.tasks import match
   match(task.id)
+
+
+def test_matchers(admin_client):
+  response = admin_client.get('/collab/matches/matchers/',
+                              content_type="application/json")
+  assert_response(response, status.HTTP_200_OK, matchers_list)


### PR DESCRIPTION
implements #94

- [x] Add "methods" column to the Task model (should encode a list of strings, not supported by built-in django field classes).
- [x] Add the new field to the Task serializer & view.
- [x] Read methods field in `server/collab/tasks.py:match` and filter used metch classes.
- [x] submit list of selected match functions through the GUI (mostly uncommenting code).
- [x] (optional) receive list of available match functions from django and automatically populate checkbox array.
- [x] tests, waiting for #219 
- [x] handle >5 args issue, waiting for #217 
- [x] resolve conflicts regarding matches/matchers after #214 is merged

Signed-off-by: Nir Izraeli <nirizr@gmail.com>