### PR TITLE
Add binary data identity hash matcher

### DIFF
--- a/idaplugin/rematch/collectors/__init__.py
+++ b/idaplugin/rematch/collectors/__init__.py
@@ -1,5 +1,6 @@
 from .collector import Collector
 from .vector import Vector
+from .identity_hash import IdentityHashVector
 from .name_hash import NameHashVector
 from .assembly_hash import AssemblyHashVector
 from .mnemonic_hash import MnemonicHashVector
@@ -17,7 +18,7 @@ def collect(offset, collectors):
       yield c.serialize()
 
 
-__all__ = ["collect", "Collector", "Vector", "NameHashVector",
-           "AssemblyHashVector", "MnemonicHashVector", "MnemonicHistVector",
-           "Annotation", "NameAnnotation", "AssemblyAnnotation",
-           "PrototypeAnnotation"]
+__all__ = ["collect", "Collector", "Vector", "IdentityHashVector",
+           "NameHashVector", "AssemblyHashVector", "MnemonicHashVector",
+           "MnemonicHistVector", "Annotation", "NameAnnotation",
+           "AssemblyAnnotation", "PrototypeAnnotation"]

--- a/idaplugin/rematch/collectors/identity_hash.py
+++ b/idaplugin/rematch/collectors/identity_hash.py
@@ -1,0 +1,29 @@
+import idautils
+import idc
+
+from .vector import Vector
+
+
+class IdentityHashVector(Vector):
+  type = 'identity_hash'
+  type_version = 0
+
+  def __init__(self, **kwargs):
+    super(IdentityHashVector, self).__init__(**kwargs)
+    self.hash = 17391172068829961267
+
+  def _cycle(self, b):
+    self.hash |= 5
+    self.hash ^= b
+    self.hash *= self.hash
+    self.hash ^= (self.hash >> 32)
+    self.hash &= 0xffffffffffffffff
+
+  def _data(self):
+    for ea in idautils.FuncItems(self.offset):
+      self._cycle(idc.Byte(ea))
+      if idc.isRef(idc.GetFlags(ea)):
+        continue
+      for i in range(ea + 1, ea + idc.ItemSize(ea)):
+        self._cycle(idc.Byte(i))
+    return self.hash

--- a/idaplugin/rematch/collectors/identity_hash.py
+++ b/idaplugin/rematch/collectors/identity_hash.py
@@ -8,9 +8,13 @@ class IdentityHashVector(Vector):
   type = 'identity_hash'
   type_version = 0
 
+  # The Keleven
+  # http://movies.stackexchange.com/q/11495
+  keleven = 17391172068829961267
+
   def __init__(self, **kwargs):
     super(IdentityHashVector, self).__init__(**kwargs)
-    self.hash = 17391172068829961267
+    self.hash = self.keleven
 
   def _cycle(self, b):
     self.hash |= 5

--- a/idaplugin/rematch/collectors/identity_hash.py
+++ b/idaplugin/rematch/collectors/identity_hash.py
@@ -26,7 +26,8 @@ class IdentityHashVector(Vector):
   def _data(self):
     for ea in idautils.FuncItems(self.offset):
       self._cycle(idc.Byte(ea))
-      if idc.isRef(idc.GetFlags(ea)):
+      # skip additional bytes of any instruction that contains an offset in it
+      if idautils.CodeRefsFrom(ea, True) or idautils.DataRefsFrom(ea):
         continue
       for i in range(ea + 1, ea + idc.ItemSize(ea)):
         self._cycle(idc.Byte(i))

--- a/idaplugin/rematch/instances/function.py
+++ b/idaplugin/rematch/instances/function.py
@@ -15,7 +15,8 @@ class FunctionInstance(EmptyFunctionInstance):
 
   def __init__(self, *args, **kwargs):
     super(FunctionInstance, self).__init__(*args, **kwargs)
-    self.vectors |= {collectors.AssemblyHashVector,
+    self.vectors |= {collectors.IdentityHashVector,
+                     collectors.AssemblyHashVector,
                      collectors.MnemonicHashVector,
                      collectors.MnemonicHistVector}
     self.annotations |= {collectors.AssemblyAnnotation}

--- a/server/collab/matchers/__init__.py
+++ b/server/collab/matchers/__init__.py
@@ -1,11 +1,12 @@
+from .identity_hash import IdentityHashMatcher
 from .assembly_hash import AssemblyHashMatcher
 from .mnemonic_hash import MnemonicHashMatcher
 from .name_hash import NameHashMatcher
 from .mnemonic_hist import MnemonicHistogramMatcher
 
 
-matchers_list = [NameHashMatcher, AssemblyHashMatcher, MnemonicHashMatcher,
-                 MnemonicHistogramMatcher]
+matchers_list = [IdentityHashMatcher, NameHashMatcher, AssemblyHashMatcher,
+                 MnemonicHashMatcher, MnemonicHistogramMatcher]
 
-__all__ = ['AssemblyHashMatcher', 'MnemonicHashMatcher', 'NameHashMatcher',
-           'MnemonicHistogramMatcher', 'matchers_list']
+__all__ = ['IdentityHashMatcher', 'AssemblyHashMatcher', 'MnemonicHashMatcher',
+           'NameHashMatcher', 'MnemonicHistogramMatcher', 'matchers_list']

--- a/server/collab/matchers/identity_hash.py
+++ b/server/collab/matchers/identity_hash.py
@@ -1,0 +1,6 @@
+from . import hash_matcher
+
+
+class IdentityHashMatcher(hash_matcher.HashMatcher):
+  vector_type = 'identity_hash'
+  match_type = 'identity_hash'


### PR DESCRIPTION
This is an old matcher from the original rematch project.
This aims to generate a unique hash for a function based on its exact binary instructions, only ignoring reference offsets (as those might change based on the function's location in the file even for exact copies).
Reference offsets are ignored by only taking the first instruction byte, by operating under the assumption the first byte holds the type of reference (call, jump, conditional jump) and subsequent bytes the actual offsets.