### PR TITLE
Separate client UI and actions better part one

### DIFF
--- a/idaplugin/rematch/actions/base.py
+++ b/idaplugin/rematch/actions/base.py
@@ -7,20 +7,19 @@ import idc
 class Action(idaapi.action_handler_t):
   """Actions are objects registered to IDA's interface and added to the
   rematch menu and toolbar"""
-  dialog = None
-
   reject_handler = None
   finish_handler = None
   submit_handler = None
   response_handler = None
   exception_handler = None
 
-  def __init__(self):
+  def __init__(self, ui_class):
     self._icon = None
-    self.dlg = None
+    self.ui_class = ui_class
+    self.ui = None
 
   def __repr__(self):
-    return "<Action: {}>".format(self.get_id())
+    return "<Action: {}, {}>".format(self.get_id(), self.ui_class)
 
   def __del__(self):
     if self._icon:
@@ -81,23 +80,20 @@ class Action(idaapi.action_handler_t):
 
     return '/'.join(t)
 
-  @classmethod
-  def register(cls):
-    action = cls()
-    r = idaapi.register_action(action.get_desc())
+  def register(self):
+    r = idaapi.register_action(self.get_desc())
     if not r:
-      log('actions').warn("failed registering %s: %s", cls, r)
+      log('actions').warn("failed registering %s: %s", self, r)
       return
     idaapi.attach_action_to_menu(
-        action.get_action_path(),
-        action.get_id(),
+        self.get_action_path(),
+        self.get_id(),
         idaapi.SETMENU_APP)
     r = idaapi.attach_action_to_toolbar(
         "AnalysisToolBar",
-        action.get_id())
+        self.get_id())
     if not r:
-      log('actions').warn("registration of %s failed: %s", cls, r)
-    return action
+      log('actions').warn("registration of %s failed: %s", self, r)
 
   def update(self, ctx):
     return idaapi.AST_ENABLE if self.enabled(ctx) else idaapi.AST_DISABLE
@@ -107,25 +103,25 @@ class Action(idaapi.action_handler_t):
     if self.running():
       return
 
-    if callable(self.dialog):
-      self.dlg = self.dialog(reject_handler=self.reject_handler,
-                             submit_handler=self.submit_handler,
-                             response_handler=self.response_handler,
-                             exception_handler=self.exception_handler)
+    if callable(self.ui_class):
+      self.ui = self.ui_class(reject_handler=self.reject_handler,
+                              submit_handler=self.submit_handler,
+                              response_handler=self.response_handler,
+                              exception_handler=self.exception_handler)
       if self.finish_handler:
-        self.dlg.finished.connect(self.finish_handler)
-      self.dlg.finished.connect(self.close_dialog)
-      self.dlg.finished.connect(self.force_update)
-      self.dlg.show()
+        self.ui.finished.connect(self.finish_handler)
+      self.ui.finished.connect(self.close_dialog)
+      self.ui.finished.connect(self.force_update)
+      self.ui.show()
     else:
       log('actions').warn("%s: no activation", self.__class__)
 
   def running(self):
-    return self.dlg is not None
+    return self.ui is not None
 
   def close_dialog(self):
-    del self.dlg
-    self.dlg = None
+    del self.ui
+    self.ui = None
 
   @staticmethod
   def force_update():

--- a/idaplugin/rematch/actions/login.py
+++ b/idaplugin/rematch/actions/login.py
@@ -3,16 +3,13 @@ from .. import user
 from .. import config
 from .. import exceptions
 
-from ..dialogs.login import LoginDialog
-
 
 class LoginAction(base.UnauthAction):
   name = "&Login"
   group = "User"
-  dialog = LoginDialog
 
-  def __init__(self):
-    super(LoginAction, self).__init__()
+  def __init__(self, *args, **kwargs):
+    super(LoginAction, self).__init__(*args, **kwargs)
     self.username = None
     self.password = None
     self.server = None
@@ -34,8 +31,8 @@ class LoginAction(base.UnauthAction):
   def handle_login(self, response):
     del response
 
-    self.dlg.statusLbl.setText("Connected!")
-    self.dlg.statusLbl.setStyleSheet("color: green;")
+    self.ui.statusLbl.setText("Connected!")
+    self.ui.statusLbl.setStyleSheet("color: green;")
 
     config['login']['username'] = self.username
     config['login']['server'] = self.server
@@ -45,17 +42,17 @@ class LoginAction(base.UnauthAction):
       config['login']['password'] = ""
     config.save()
 
-    self.dlg.accept()
+    self.ui.accept()
 
   def handle_exception(self, exception):
     if isinstance(exception, (exceptions.ConnectionException,
                               exceptions.ServerException)):
-      self.dlg.statusLbl.setText("Connection to server failed.")
-      self.dlg.statusLbl.setStyleSheet("color: blue;")
+      self.ui.statusLbl.setText("Connection to server failed.")
+      self.ui.statusLbl.setStyleSheet("color: blue;")
     elif isinstance(exception, (exceptions.QueryException,
                                 exceptions.AuthenticationException)):
-      self.dlg.statusLbl.setText("Invalid user name or password.")
-      self.dlg.statusLbl.setStyleSheet("color: red;")
+      self.ui.statusLbl.setText("Invalid user name or password.")
+      self.ui.statusLbl.setStyleSheet("color: red;")
 
 
 class LogoutAction(base.AuthAction):

--- a/idaplugin/rematch/actions/project.py
+++ b/idaplugin/rematch/actions/project.py
@@ -1,5 +1,4 @@
 from . import base
-from ..dialogs.project import AddProjectDialog, AddFileDialog
 
 from .. import netnode
 from .. import network
@@ -8,7 +7,6 @@ from .. import network
 class AddProjectAction(base.AuthAction):
   name = "&Add project"
   group = "Project"
-  dialog = AddProjectDialog
 
   @staticmethod
   def submit_handler(name, description, private, bind_current):
@@ -31,7 +29,6 @@ class AddProjectAction(base.AuthAction):
 class AddFileAction(base.UnboundFileAction):
   name = "&Add file"
   group = "Project"
-  dialog = AddFileDialog
 
   @staticmethod
   def submit_handler(project, name, md5hash, description, shareidb):

--- a/idaplugin/rematch/actions/settings.py
+++ b/idaplugin/rematch/actions/settings.py
@@ -4,7 +4,7 @@ from . import base
 from .. import config
 
 
-class SettingsAction(base.Action):
+class SettingsAction(base.IDAAction):
   name = "&Settings"
 
   @staticmethod

--- a/idaplugin/rematch/actions/settings.py
+++ b/idaplugin/rematch/actions/settings.py
@@ -3,12 +3,9 @@ import idaapi
 from . import base
 from .. import config
 
-from ..dialogs.settings import SettingsDialog
-
 
 class SettingsAction(base.Action):
   name = "&Settings"
-  dialog = SettingsDialog
 
   @staticmethod
   def submit_handler(autocheck, autoupdate, autologin, autologout, debug):

--- a/idaplugin/rematch/plugin.py
+++ b/idaplugin/rematch/plugin.py
@@ -4,6 +4,7 @@ import idaapi
 
 from . import config, user
 from . import actions
+from . import dialogs
 from . import update
 
 
@@ -47,15 +48,16 @@ class RematchPlugin(idaapi.plugin_t):
     self.menu = QtWidgets.QMenu("Rematch")
     self.get_mainwindow().menuWidget().addMenu(self.menu)
 
-    actions.login.LoginAction.register()
-    actions.login.LogoutAction.register()
+    actions.login.LoginAction(dialogs.login.LoginDialog).register()
+    actions.login.LogoutAction(None).register()
 
-    actions.project.AddProjectAction.register()
-    actions.project.AddFileAction.register()
+    actions.project.AddProjectAction(dialogs.project.
+                                     AddProjectDialog).register()
+    actions.project.AddFileAction(dialogs.project.AddFileDialog).register()
 
-    actions.match.MatchAction.register()
+    actions.match.MatchAction(dialogs.match.MatchDialog).register()
 
-    actions.settings.SettingsAction.register()
+    actions.settings.SettingsAction(dialogs.settings.SettingsDialog).register()
 
     # set up status bar
     self.statusbar_label = QtWidgets.QLabel("Rematch loaded")


### PR DESCRIPTION
This is the first step in sharing actions code between different clients.
This is also needed for a decent #221, sharing actions between dialog based and gui-less interfaces.

Signed-off-by: Nir Izraeli <nirizr@gmail.com>