### PR TITLE
Fix coveralls errors with nodata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,9 @@ before_script:
 
 script:
   - flake8 ./${PROJECT} --show-source --statistics
-  - if [ -d ./tests/${PROJECT} ]; then flake8 ./tests/${PROJECT} --show-source; fi
+  - if [ -d ./tests/${PROJECT} ]; then flake8 ./tests/${PROJECT} --show-source ; fi
   - if [ -d ./tests/${PROJECT} ]; then py.test ./${PROJECT} ./tests/${PROJECT} --verbose --cov-report= --cov=$PROJECT ; fi
   - ./setup.py ${PROJECT} sdist --formats=zip ; pip install ./dist/rematch-${PROJECT}-*.zip
 
 after_success:
-  - coveralls
+  - if [ -d ./tests/${PROJECT} ]; then coveralls ; fi


### PR DESCRIPTION
When running coveralls with no tests, a job with no data is created in coveralls.io
such jobs make coverall assume there was an error reporting the data, and thus failing

This PR makes sure coveralls is only called when there are tests in the project

Signed-off-by: Nir Izraeli <nirizr@gmail.com>