### PR TITLE
Add 'release' command to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def find_packages_relative(base):
            for package in find_packages(base)]
 
 def build_setup(name, package_name, version_path, package_base,
-                package_data=None):
+                package_data=None, script_args=None):
   if package_data is None:
     package_data = {}
 
@@ -54,6 +54,7 @@ def build_setup(name, package_name, version_path, package_base,
   version_path = os.path.join(base_path, package_base, version_path)
   readme_path = os.path.join(base_path, "README.rst")
   setup(
+    script_args=script_args,
     name = package_name,
     version = get_version(version_path),
     author = "Nir Izraeli",
@@ -73,27 +74,46 @@ def build_setup(name, package_name, version_path, package_base,
     ],
   )
 
-if __name__ == '__main__':
-  packages = set(os.listdir('.')) & {'server', 'idaplugin'}
+def build_setup_server(script_args=None):
+  build_setup(name='server',
+              package_name='rematch-server',
+              version_path='./',
+              package_base='server',
+              script_args=script_args)
 
-  if len(sys.argv) < 2:
+
+def build_setup_idaplugin(script_args=None):
+  package_data = {'idaplugin/rematch': ['images/*']}
+  build_setup(name='idaplugin',
+              package_name='rematch-idaplugin',
+              version_path='rematch',
+              package_base='idaplugin',
+              package_data=package_data,
+              script_args=script_args)
+
+
+if __name__ == '__main__':
+  expected_packages = {'server', 'idaplugin'}
+  packages = set(os.listdir('.')) & expected_packages
+
+  if len(sys.argv) < 2 and len(packages) > 1:
     print("Usage: {} {{package name}}".format(sys.argv[0]))
     print("Available packages are: {}".format(", ".join(packages)))
     sys.exit(1)
 
-  package = packages.pop() if len(packages) == 1 else sys.argv[1]
-
-  if sys.argv[1] == package:
-    sys.argv = sys.argv[:1] + sys.argv[2:]
-  if package  == 'server':
-    build_setup(name='server',
-                package_name='rematch-server',
-                version_path='./',
-                package_base='server')
-  elif package == 'idaplugin':
-    package_data = {'idaplugin/rematch': ['images/*']}
-    build_setup(name='idaplugin',
-                package_name='rematch-idaplugin',
-                version_path='rematch',
-                package_base='idaplugin',
-                package_data=package_data)
+  # If all packages are available, allow a 'release' command that would push
+  # all packages to pypi
+  if sys.argv[1] == 'release' and packages == expected_packages:
+    script_args = ['sdist', '--dist-dir=./dist', '--formats=zip', 'upload']
+    if not (len(sys.argv) >= 3 and sys.argv[2] == 'official'):
+      script_args += ['-r', 'pypitest']
+    build_setup_server(script_args=script_args)
+    build_setup_idaplugin(script_args=script_args)
+  else:
+    package = packages.pop() if len(packages) == 1 else sys.argv[1]
+    if sys.argv[1] == package:
+      sys.argv = sys.argv[:1] + sys.argv[2:]
+    if package  == 'server':
+      build_setup_server()
+    elif package == 'idaplugin':
+      build_setup_idaplugin()


### PR DESCRIPTION
Running './setup.py release' will now build zip sdists of both packages and upload them.
Adding 'official' to that command will upload them to the official pypi server instead of pypitest.

Signed-off-by: Nir Izraeli <nirizr@gmail.com>