### PR TITLE
Remove pytest django conf

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = rematch.settings
 norecursedirs = venv
 addopts = --nomigrations


### PR DESCRIPTION
We're using environment variable defined in .travis.yml

Signed-off-by: Nir Izraeli <nirizr@gmail.com>