### PR TITLE
Fix IdentityHashVector inheritance bugs

### DIFF
--- a/idaplugin/rematch/collectors/collector.py
+++ b/idaplugin/rematch/collectors/collector.py
@@ -7,7 +7,7 @@ except NameError:
   strtypes = (str,)
 
 
-class Collector:
+class Collector(object):
   def __init__(self, offset, instance_id=None):
     self.instance_id = instance_id
     self.offset = offset

--- a/idaplugin/rematch/collectors/vectors/identity_hash.py
+++ b/idaplugin/rematch/collectors/vectors/identity_hash.py
@@ -12,9 +12,9 @@ class IdentityHashVector(vector.Vector):
   # http://movies.stackexchange.com/q/11495
   keleven = 17391172068829961267
 
-  def __init__(self, **kwargs):
-    super(IdentityHashVector, self).__init__(**kwargs)
+  def __init__(self, *args, **kwargs):
     self.hash = self.keleven
+    super(IdentityHashVector, self).__init__(*args, **kwargs)
 
   def _cycle(self, b):
     self.hash |= 5


### PR DESCRIPTION
* forgot to pass *args from subclass __init__
* forgot to inherit object in parent class

Signed-off-by: Nir Izraeli <nirizr@gmail.com>