### PR TITLE
in case we get an empty matcher dictionary don't crash

### DIFF
--- a/idaplugin/rematch/dialogs/widgets.py
+++ b/idaplugin/rematch/dialogs/widgets.py
@@ -66,18 +66,19 @@ class QItemCheckBoxes(QtWidgets.QGridLayout):
 
     self.checkboxes = []
     for i, obj in enumerate(response):
-      item_name = obj[self.name_field]
-      item_id = obj[self.id_field]
+      if obj != {}:
+        item_name = obj[self.name_field]
+        item_id = obj[self.id_field]
 
-      if self.exclude and (item_name in self.exclude or
-                           item_id in self.exclude):
-        continue
+        if self.exclude and (item_name in self.exclude or
+                             item_id in self.exclude):
+          continue
 
-      checkbox_widget = QtWidgets.QCheckBox(item_name)
-      checkbox_widget.id = item_id
-      checkbox_widget.setChecked(True)
-      self.addWidget(checkbox_widget, i / self.columns, i % self.columns)
-      self.checkboxes.append(checkbox_widget)
+        checkbox_widget = QtWidgets.QCheckBox(item_name)
+        checkbox_widget.id = item_id
+        checkbox_widget.setChecked(True)
+        self.addWidget(checkbox_widget, i / self.columns, i % self.columns)
+        self.checkboxes.append(checkbox_widget)
 
   def get_result(self):
     return [cb.id for cb in self.checkboxes if cb.isChecked()]

--- a/idaplugin/rematch/dialogs/widgets.py
+++ b/idaplugin/rematch/dialogs/widgets.py
@@ -66,19 +66,20 @@ class QItemCheckBoxes(QtWidgets.QGridLayout):
 
     self.checkboxes = []
     for i, obj in enumerate(response):
-      if obj:
-        item_name = obj[self.name_field]
-        item_id = obj[self.id_field]
+      if not obj:
+        continue
+      item_name = obj[self.name_field]
+      item_id = obj[self.id_field]
 
-        if self.exclude and (item_name in self.exclude or
-                             item_id in self.exclude):
-          continue
+      if self.exclude and (item_name in self.exclude or
+                           item_id in self.exclude):
+        continue
 
-        checkbox_widget = QtWidgets.QCheckBox(item_name)
-        checkbox_widget.id = item_id
-        checkbox_widget.setChecked(True)
-        self.addWidget(checkbox_widget, i / self.columns, i % self.columns)
-        self.checkboxes.append(checkbox_widget)
+      checkbox_widget = QtWidgets.QCheckBox(item_name)
+      checkbox_widget.id = item_id
+      checkbox_widget.setChecked(True)
+      self.addWidget(checkbox_widget, i / self.columns, i % self.columns)
+      self.checkboxes.append(checkbox_widget)
 
   def get_result(self):
     return [cb.id for cb in self.checkboxes if cb.isChecked()]

--- a/idaplugin/rematch/dialogs/widgets.py
+++ b/idaplugin/rematch/dialogs/widgets.py
@@ -66,7 +66,7 @@ class QItemCheckBoxes(QtWidgets.QGridLayout):
 
     self.checkboxes = []
     for i, obj in enumerate(response):
-      if obj != {}:
+      if obj:
         item_name = obj[self.name_field]
         item_id = obj[self.id_field]
 


### PR DESCRIPTION
I'm sure there is a better way than 
```
if obj != {}
```

I'll commit something better soon.
