### PR TITLE
Validate all matchers in 'matchers_list' are not abstract

### DIFF
--- a/server/collab/matchers/matcher.py
+++ b/server/collab/matchers/matcher.py
@@ -3,3 +3,9 @@ class Matcher:
   def match(cls, source, target):
     raise NotImplementedError("Method match for vector type {} not "
                               "implemented".format(cls))
+
+  @classmethod
+  def is_abstract(cls):
+    return not (getattr(cls, 'vector_type') and
+                getattr(cls, 'match_type') and
+                getattr(cls, 'matcher_name'))

--- a/server/collab/views.py
+++ b/server/collab/views.py
@@ -160,6 +160,8 @@ class MatchViewSet(viewsets.ReadOnlyModelViewSet):
   @decorators.list_route()
   def matchers(request):
     del request
+    if any((m.is_abstract() for m in matchers_list)):
+      raise Exception("Abstract matcher in list")
     serializer = MatcherSerializer(matchers_list, many=True)
     return response.Response(serializer.data)
 


### PR DESCRIPTION
A complementary to #315, raise a server error if we ever try serving one.
This will catch similar errors while testing.

If you don't like it we can replace is with a specific test to assert all matchers implement those attributes.

Signed-off-by: Nir Izraeli <nirizr@gmail.com>