### PR TITLE
handle logger level changes in config

### DIFF
--- a/idaplugin/rematch/logger.py
+++ b/idaplugin/rematch/logger.py
@@ -8,4 +8,6 @@ def log(module):
   logger = logging.getLogger(module)
   if 'debug' in config and config['debug']:
     logger.setLevel(logging.DEBUG)
+  else:
+    logger.setLevel(logging.WARN)
   return logger


### PR DESCRIPTION
When getting a logger, level was only changed if settings we're set to
debug. By setting the logger level regardless, this fixes #326.

Signed-off-by: Nir Izraeli <nirizr@gmail.com>