### PR TITLE
Reduce bandwidth sent on match results

### DIFF
--- a/idaplugin/rematch/collectors/__init__.py
+++ b/idaplugin/rematch/collectors/__init__.py
@@ -13,25 +13,21 @@ def collect(collectors, offset, instance_id=None):
       yield r
 
 
-def apply(offset, data):
-  for _, annotation in inspect.getmembers(annotations):
-    if not (inspect.isclass(annotation) and hasattr(annotation, 'type')):
+def apply(offset, annotation):
+  for _, annotation_cls in inspect.getmembers(annotations):
+    if not (inspect.isclass(annotation_cls) and
+            hasattr(annotation_cls, 'type') and
+            annotation_cls.type == annotation['type']):
       continue
-    annotation_type = annotation.type
 
-    annotation_data = [_d for _d in data if _d['type'] == annotation_type]
-    if len(annotation_data) == 0:
-      continue
-    elif len(annotation_data) > 1:
-      raise ValueError("Found more then one annotation fitting type")
-    annotation_data = json.loads(annotation_data[0]['data'])
+    annotation_data = json.loads(annotation['data'])
 
-    if annotation.data(offset) == annotation_data:
+    if annotation_cls.data(offset) == annotation_data:
       log('annotation_apply').info("Setting annotation %s skipped at %s with "
                                    "%s because value is already set",
-                                   annotation, offset, annotation_data)
+                                   annotation_cls, offset, annotation_data)
     else:
-      annotation.apply(offset, annotation_data)
+      annotation_cls.apply(offset, annotation_data)
 
 
 __all__ = ["collect", "apply", "vectors", "annotations"]

--- a/idaplugin/rematch/dialogs/matchresult.py
+++ b/idaplugin/rematch/dialogs/matchresult.py
@@ -207,7 +207,7 @@ class MatchResultDialog(gui.GuiDialog):
                                                 len(self.matched_map))
     for local_item, remote_item in self.enumerate_items():
       if remote_item.checkState(self.CHECKBOX_COLUMN):
-        local_offset = self.get_obj(local_item.api_id)
+        local_offset = self.get_obj(local_item.api_id)['offset']
         if remote_item.api_id in self.matched_map:
           self.matched_map[remote_item.api_id].append(local_offset)
         else:
@@ -219,15 +219,12 @@ class MatchResultDialog(gui.GuiDialog):
     q.start(self.handle_apply_matches)
 
   def handle_apply_matches(self, response):
-    print(response)
     for annotation in response:
-      print(annotation)
       remote_id = annotation['instance']
       local_offsets = self.matched_map[remote_id]
-      annotations_data = annotation['data']
 
       for local_offset in local_offsets:
-        collectors.apply(local_offset, annotations_data)
+        collectors.apply(local_offset, annotation)
 
   def clear_checks(self):
     for _, remote_item in self.enumerate_items():

--- a/idaplugin/rematch/dialogs/matchresult.py
+++ b/idaplugin/rematch/dialogs/matchresult.py
@@ -203,6 +203,8 @@ class MatchResultDialog(gui.GuiDialog):
     return sum(1 for _ in self.enumerate_items())
 
   def apply_matches(self):
+    self.matched_map = {}
+
     for local_item, remote_item in self.enumerate_items():
       if remote_item.checkState(self.CHECKBOX_COLUMN):
         local_offset = self.get_obj(local_item.api_id)['offset']
@@ -212,6 +214,9 @@ class MatchResultDialog(gui.GuiDialog):
           self.matched_map[remote_item.api_id] = [local_offset]
 
     item_count = sum(len(m) for m in self.matched_map.values())
+    if not item_count:
+      return
+
     self.apply_pbar = QtWidgets.QProgressDialog("", "&Cancel", 0, item_count)
 
     q = network.QueryWorker("GET", "collab/annotations/", json=True,

--- a/idaplugin/rematch/dialogs/matchresult.py
+++ b/idaplugin/rematch/dialogs/matchresult.py
@@ -203,8 +203,6 @@ class MatchResultDialog(gui.GuiDialog):
     return sum(1 for _ in self.enumerate_items())
 
   def apply_matches(self):
-    self.apply_pbar = QtWidgets.QProgressDialog("", "&Cancel", 0,
-                                                len(self.matched_map))
     for local_item, remote_item in self.enumerate_items():
       if remote_item.checkState(self.CHECKBOX_COLUMN):
         local_offset = self.get_obj(local_item.api_id)['offset']
@@ -212,6 +210,9 @@ class MatchResultDialog(gui.GuiDialog):
           self.matched_map[remote_item.api_id].append(local_offset)
         else:
           self.matched_map[remote_item.api_id] = [local_offset]
+
+    item_count = sum(len(m) for m in self.matched_map.values())
+    self.apply_pbar = QtWidgets.QProgressDialog("", "&Cancel", 0, item_count)
 
     q = network.QueryWorker("GET", "collab/annotations/", json=True,
                             params={"instance": self.matched_map.keys()},
@@ -225,6 +226,7 @@ class MatchResultDialog(gui.GuiDialog):
 
       for local_offset in local_offsets:
         collectors.apply(local_offset, annotation)
+        self.apply_pbar.setValue(self.apply_pbar.value() + 1)
 
   def clear_checks(self):
     for _, remote_item in self.enumerate_items():

--- a/idaplugin/rematch/dialogs/matchresult.py
+++ b/idaplugin/rematch/dialogs/matchresult.py
@@ -217,7 +217,7 @@ class MatchResultDialog(gui.GuiDialog):
     q = network.QueryWorker("GET", "collab/annotations/", json=True,
                             params={"instance": self.matched_map.keys()},
                             splittable="instance")
-    q.start(self.handle_apply_matches)
+    q.start(self.handle_apply_matches, requeue='write')
 
   def handle_apply_matches(self, response):
     for annotation in response:

--- a/idaplugin/rematch/dialogs/matchresult.py
+++ b/idaplugin/rematch/dialogs/matchresult.py
@@ -35,6 +35,8 @@ class MatchResultDialog(gui.GuiDialog):
     self.locals = {}
     self.remotes = {}
     self.matches = []
+    self.apply_pbar = None
+    self.matched_map = {}
 
     self.script_code = None
     self.script_compile = None
@@ -201,23 +203,31 @@ class MatchResultDialog(gui.GuiDialog):
     return sum(1 for _ in self.enumerate_items())
 
   def apply_matches(self):
-    apply_pbar = QtWidgets.QProgressDialog("", "&Cancel", 0,
-                                           self.items_count())
+    self.apply_pbar = QtWidgets.QProgressDialog("", "&Cancel", 0,
+                                                len(self.matched_map))
     for local_item, remote_item in self.enumerate_items():
-      apply_pbar.setValue(apply_pbar.value() + 1)
-
       if remote_item.checkState(self.CHECKBOX_COLUMN):
-        self.apply_match(local_item, remote_item)
+        local_offset = self.get_obj(local_item.api_id)
+        if remote_item.api_id in self.matched_map:
+          self.matched_map[remote_item.api_id].append(local_offset)
+        else:
+          self.matched_map[remote_item.api_id] = [local_offset]
 
-    # refresh ida's views
-    ida_kernwin.refresh_idaview_anyway()
+    q = network.QueryWorker("GET", "collab/annotations/", json=True,
+                            params={"instance": self.matched_map.keys()},
+                            splittable="instance")
+    q.start(self.handle_apply_matches)
 
-  def apply_match(self, local_item, remote_item):
-    remote_id = remote_item.api_id
-    annotations_data = self.remotes[remote_id]['annotations']
-    local_id = local_item.api_id
-    local_offset = self.locals[local_id]['offset']
-    collectors.apply(local_offset, annotations_data)
+  def handle_apply_matches(self, response):
+    print(response)
+    for annotation in response:
+      print(annotation)
+      remote_id = annotation['instance']
+      local_offsets = self.matched_map[remote_id]
+      annotations_data = annotation['data']
+
+      for local_offset in local_offsets:
+        collectors.apply(local_offset, annotations_data)
 
   def clear_checks(self):
     for _, remote_item in self.enumerate_items():

--- a/server/collab/serializers.py
+++ b/server/collab/serializers.py
@@ -58,15 +58,12 @@ class TaskEditSerializer(TaskSerializer):
   matchers = serializers.ReadOnlyField()
 
 
-class InstanceSerializer(serializers.ModelSerializer):
-  owner = serializers.ReadOnlyField(source='owner.username')
-  file = serializers.ReadOnlyField(source='file_version.file_id')
+class SlimInstanceSerializer(serializers.ModelSerializer):
   name = serializers.SerializerMethodField()
 
   class Meta:
     model = Instance
-    fields = ('id', 'owner', 'file', 'file_version', 'type', 'name', 'offset',
-              'vectors', 'annotations')
+    fields = ('id', 'type', 'name', 'offset')
 
   @staticmethod
   def get_name(instance):
@@ -85,11 +82,7 @@ class AnnotationSerializer(serializers.ModelSerializer):
     fields = ('id', 'instance', 'type', 'data')
 
 
-class InstanceVectorSerializer(InstanceSerializer):
-  owner = serializers.ReadOnlyField(source='owner.username')
-  file = serializers.ReadOnlyField(source='file_version.file_id')
-  name = serializers.SerializerMethodField()
-
+class InstanceVectorSerializer(serializers.ModelSerializer):
   class NestedVectorSerializer(serializers.ModelSerializer):
     class Meta:
       model = Vector
@@ -100,8 +93,16 @@ class InstanceVectorSerializer(InstanceSerializer):
       model = Annotation
       fields = ('id', 'type', 'data')
 
+  owner = serializers.ReadOnlyField(source='owner.username')
+  file = serializers.ReadOnlyField(source='file_version.file_id')
+  name = serializers.SerializerMethodField()
   vectors = NestedVectorSerializer(many=True, required=True)
   annotations = NestedAnnotationSerializer(many=True, required=True)
+
+  class Meta:
+    model = Instance
+    fields = ('id', 'owner', 'file', 'file_version', 'type', 'name', 'offset',
+              'vectors', 'annotations')
 
   def create(self, validated_data):
     vectors_data = validated_data.pop('vectors')

--- a/server/collab/views.py
+++ b/server/collab/views.py
@@ -6,7 +6,7 @@ from collab.serializers import (ProjectSerializer, FileSerializer,
                                 FileVersionSerializer, TaskSerializer,
                                 TaskEditSerializer, InstanceVectorSerializer,
                                 VectorSerializer, MatchSerializer,
-                                InstanceSerializer, AnnotationSerializer,
+                                SlimInstanceSerializer, AnnotationSerializer,
                                 MatcherSerializer)
 from collab.permissions import IsOwnerOrReadOnly
 from collab import tasks
@@ -102,10 +102,10 @@ class TaskViewSet(mixins.CreateModelMixin, mixins.RetrieveModelMixin,
     # pagination code
     page = self.paginate_queryset(queryset)
     if page is not None:
-      serializer = InstanceSerializer(page, many=True)
+      serializer = SlimInstanceSerializer(page, many=True)
       return self.get_paginated_response(serializer.data)
     else:
-      serializer = InstanceSerializer(queryset, many=True)
+      serializer = SlimInstanceSerializer(queryset, many=True)
       return response.Response(serializer.data)
 
   @decorators.detail_route(url_path="remotes")
@@ -122,10 +122,10 @@ class TaskViewSet(mixins.CreateModelMixin, mixins.RetrieveModelMixin,
     # pagination code
     page = self.paginate_queryset(queryset)
     if page is not None:
-      serializer = InstanceVectorSerializer(page, many=True)
+      serializer = SlimInstanceSerializer(page, many=True)
       return self.get_paginated_response(serializer.data)
     else:
-      serializer = InstanceVectorSerializer(queryset, many=True)
+      serializer = SlimInstanceSerializer(queryset, many=True)
       return response.Response(serializer.data)
 
   @decorators.detail_route(url_path="matches")


### PR DESCRIPTION
remaining:
- [x] fetch all annotations for selected remotes, and apply using that instead
- [x] Use main thread queuing functionality added in #334 to avoid crashes
- [x] When the Apply Matches button is pressed with 0 matches, a progress bar pops up and never disappears.


This should at least somewhat address #325 

Signed-off-by: Nir Izraeli <nirizr@gmail.com>