### PR TITLE
Support splitting a request to multiple requests

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -16,7 +16,7 @@ pylint:
   disable:
     - bad-indentation
   options:
-    max-args: 8
+    max-args: 10
 pep8:
   disable:
     - E114

--- a/idaplugin/rematch/actions/match.py
+++ b/idaplugin/rematch/actions/match.py
@@ -229,19 +229,19 @@ class MatchAction(base.BoundFileAction):
 
     log('match_action').info("Result download started")
     locals_url = "collab/tasks/{}/locals/".format(self.task_id)
-    q = network.QueryWorker("GET", locals_url, json=True, paginate=True,
+    q = network.QueryWorker("GET", locals_url, json=True, pageable=True,
                             params={'limit': 100})
     q.start(self.handle_locals)
     self.delayed_queries.append(q)
 
     remotes_url = "collab/tasks/{}/remotes/".format(self.task_id)
-    q = network.QueryWorker("GET", remotes_url, json=True, paginate=True,
+    q = network.QueryWorker("GET", remotes_url, json=True, pageable=True,
                             params={'limit': 100})
     q.start(self.handle_remotes)
     self.delayed_queries.append(q)
 
     matches_url = "collab/tasks/{}/matches/".format(self.task_id)
-    q = network.QueryWorker("GET", matches_url, json=True, paginate=True,
+    q = network.QueryWorker("GET", matches_url, json=True, pageable=True,
                             params={'limit': 100})
     q.start(self.handle_matches)
     self.delayed_queries.append(q)


### PR DESCRIPTION
Often, there's a server side enforced limit on the number of fields sent
by a client, to protect against denial of service attacks.
By default on Django that limit is set to 1000 field values, however
that is often an issue for certain API requests.

When a single field is expected to be provided with multiple values (as
is about to happen in #329), this PR aims to provide a solution by
extending QueryWorker with the `splitable` parameter, whichh will split
that parameter to multiple requests when it exceeds a hardcoded length
of values (set to 900).

This can't be done automatically, and should be done with caution, as
only certain endpoints will yield the same result, and only with certain
parameters.

Signed-off-by: Nir Izraeli <nirizr@gmail.com>