### PR TITLE
Wrap callbacks with synced execution in network.py

### DIFF
--- a/idaplugin/rematch/netnode.py
+++ b/idaplugin/rematch/netnode.py
@@ -1,4 +1,5 @@
 from . import config
+from utils import ida_kernel_queue
 
 import ida_netnode
 import ida_kernwin
@@ -10,6 +11,7 @@ class NetNode(object):
     return ida_netnode.netnode("$rematch", 0, True)
 
   @property
+  @ida_kernel_queue(wait=True)
   def bound_file_id(self):
     bound_file_id = self._nn.hashstr('bound_file_id')
     if not bound_file_id:
@@ -20,6 +22,7 @@ class NetNode(object):
 
     return int(bound_file_id)
 
+  @ida_kernel_queue(wait=True)
   def validate_bound_server(self):
     bound_server = self._nn.hashstr('bound_server')
     if not bound_server:
@@ -46,16 +49,19 @@ class NetNode(object):
       return False
 
   @bound_file_id.setter
+  @ida_kernel_queue(write=True, wait=True)
   def bound_file_id(self, file_id):
     r = self._nn.hashset("bound_file_id", str(file_id))
     if r:
       self.bind_server()
     return r
 
+  @ida_kernel_queue(write=True, wait=True)
   def bind_server(self):
     self._nn.hashset("bound_server", str(config['login']['server']))
 
   @bound_file_id.deleter
+  @ida_kernel_queue(write=True, wait=True)
   def bound_file_id(self):
     return self._nn.hashdel("bound_file_id")
 

--- a/idaplugin/rematch/network.py
+++ b/idaplugin/rematch/network.py
@@ -7,7 +7,7 @@ from cookielib import CookieJar
 from json import loads, dumps
 
 import exceptions
-from . import config, log
+from . import config, log, utils
 
 # building opener
 cookiejar = CookieJar()
@@ -74,7 +74,8 @@ class QueryWorker(QtCore.QRunnable):
     self.started = True
 
     if requeue:
-      callback = utils.ida_kernel_queue(callback, write=(requeue == 'write'))
+      requeue = requeue == 'write'
+      callback = utils.ida_kernel_queue(write=requeue)(callback)
 
     if callback:
       self.signals.result_dict.connect(callback)

--- a/idaplugin/rematch/network.py
+++ b/idaplugin/rematch/network.py
@@ -1,7 +1,5 @@
 from idasix import QtCore
-import ida_kernwin
 
-import functools
 import urllib
 import urllib2
 from urlparse import urlparse
@@ -76,7 +74,7 @@ class QueryWorker(QtCore.QRunnable):
     self.started = True
 
     if requeue:
-      callback = build_requeue_callback(callback, requeue)
+      callback = utils.ida_kernel_queue(callback, write=(requeue == 'write'))
 
     if callback:
       self.signals.result_dict.connect(callback)
@@ -139,17 +137,6 @@ class QueryWorker(QtCore.QRunnable):
 
 def default_exception_callback(exception):
   raise exception
-
-
-def build_requeue_callback(callback, requeue):
-  reqf = ida_kernwin.MFF_READ if requeue == 'read' else ida_kernwin.MFF_WRITE
-  reqf |= ida_kernwin.MFF_NOWAIT
-
-  def enqueue(*args, **kwargs):
-    partial_callback = functools.partial(callback, *args, **kwargs)
-    return ida_kernwin.execute_sync(partial_callback, reqf)
-
-  return enqueue
 
 
 def build_params(method, params):

--- a/idaplugin/rematch/utils.py
+++ b/idaplugin/rematch/utils.py
@@ -1,5 +1,10 @@
 import os
+import functools
+
+import logger
+
 import idc
+import ida_kernwin
 
 
 def get_plugin_base(*path):
@@ -8,3 +13,23 @@ def get_plugin_base(*path):
 
 def get_plugin_path(*path):
   return get_plugin_base("rematch", *path)
+
+
+def ida_kernel_queue(callback, write=False, wait=False):
+  reqf = ida_kernwin.MFF_WRITE if write else ida_kernwin.MFF_READ
+  if not wait:
+    reqf |= ida_kernwin.MFF_NOWAIT
+
+  @functools.wraps(callback)
+  def enqueue(*args, **kwargs):
+    partial_callback = functools.partial(callback, *args, **kwargs)
+    r = ida_kernwin.execute_sync(partial_callback, reqf)
+    if r == -1:
+      logger.log('ida_main').warn("Possible failure in queueing for main "
+                                  "thread with callback: {}, reqf: {}, args: "
+                                  "{}, kwargs: {}".format(callback, reqf,
+                                                          args, kwargs))
+    elif wait:
+      return r
+
+  return enqueue

--- a/idaplugin/rematch/utils.py
+++ b/idaplugin/rematch/utils.py
@@ -17,21 +17,22 @@ def get_plugin_path(*path):
 
 class ida_kernel_queue(object):
   def __init__(self, write=False, wait=False):
+    self.wait = wait
     self.reqf = ida_kernwin.MFF_WRITE if write else ida_kernwin.MFF_READ
-    if not wait:
+    if not self.wait:
       self.reqf |= ida_kernwin.MFF_NOWAIT
 
-  def __call__(callback):
+  def __call__(self, callback):
     @functools.wraps(callback)
     def enqueue(*args, **kwargs):
       partial_callback = functools.partial(callback, *args, **kwargs)
       r = ida_kernwin.execute_sync(partial_callback, self.reqf)
       if r == -1:
-        msg = "Possible failure in queueing for main thread with callback: "
-              "{}, reqf: {}, args: {}, kwargs: {}".format(callback, self.reqf,
-                                                          args, kwargs)
+        msg = ("Possible failure in queueing for main thread with callback: "
+               "{}, reqf: {}, args: {}, kwargs: {}".format(callback, self.reqf,
+                                                           args, kwargs))
         logger.log('ida_main').warn(msg)
-      elif wait:
+      elif self.wait:
         return r
 
-  return enqueue
+    return enqueue

--- a/tests/idaplugin/requirements.txt
+++ b/tests/idaplugin/requirements.txt
@@ -1,4 +1,2 @@
 pytest
-pytest-idapro
-pytest-qt
-pytest-xvfb
+pytest-idapro>=0.1.14


### PR DESCRIPTION
Since IDA's API is not thread-safe, database and other IDA kernel related
operations must only be executed from within the main IDA thread.
Our network API violates that in cases response callback functions direcly
interact with those sensitive APIs.
To avoid this, a new functionality is added to allow users to mark callbacks
that require requeue to the main thread by providing the 'requeue' parameter.
These callbacks will be wrapped with a function to enqueue a callable in IDA's
main thread execution queue.

Signed-off-by: Nir Izraeli <nirizr@gmail.com>