### PR TITLE
Dont treat flow as code xref when skipping offset bytes

### DIFF
--- a/idaplugin/rematch/collectors/vectors/identity_hash.py
+++ b/idaplugin/rematch/collectors/vectors/identity_hash.py
@@ -30,7 +30,7 @@ class IdentityHashVector(vector.Vector):
     for ea in idautils.FuncItems(offset):
       h = cls._cycle(h, idc.Byte(ea))
       # skip additional bytes of any instruction that contains an offset in it
-      if idautils.CodeRefsFrom(ea, True) or idautils.DataRefsFrom(ea):
+      if idautils.CodeRefsFrom(ea, False) or idautils.DataRefsFrom(ea):
         continue
       for i in range(ea + 1, ea + idc.ItemSize(ea)):
         h = cls._cycle(h, idc.Byte(i))


### PR DESCRIPTION
Doing so means we're skipping offset bytes for all instructions (except the last one)

Signed-off-by: Nir Izraeli <nirizr@gmail.com>