### PR TITLE
Fix module used by widgets.py to call choose_func

### DIFF
--- a/idaplugin/rematch/dialogs/widgets.py
+++ b/idaplugin/rematch/dialogs/widgets.py
@@ -1,6 +1,7 @@
 from ..idasix import QtWidgets, QtCore
 
 import ida_funcs
+import ida_kernwin
 import idc
 
 from .. import network
@@ -170,8 +171,8 @@ class QFunctionSelect(QtWidgets.QWidget):
 
   def btn_clicked(self, checked):
     del checked
-    f = ida_funcs.choose_func("Choose function to match with database",
-                              self.func.startEA if self.func else 0)
+    f = ida_kernwin.choose_func("Choose function to match with database",
+                                self.func.startEA if self.func else 0)
     if f:
       self.set_func(f)
       self.changed.emit()


### PR DESCRIPTION
Appearntly I assumed ida_funcs implemented choose_func but in reality it was in ida_kernwin.
before ida7, modules were all mapped to idaapi so the mistake went unnoticed.

Signed-off-by: Nir Izraeli <nirizr@gmail.com>