### PR TITLE
Fix recognising result download is complete with small result set

### DIFF
--- a/idaplugin/rematch/actions/match.py
+++ b/idaplugin/rematch/actions/match.py
@@ -224,6 +224,7 @@ class MatchAction(base.BoundFileAction):
 
   def start_results(self):
     self.pbar = QtWidgets.QProgressDialog()
+    self.pbar.setAutoReset(False)
     self.pbar.canceled.connect(self.cancel)
     self.pbar.rejected.connect(self.cancel)
     self.pbar.setLabelText("Receiving match results...")


### PR DESCRIPTION
With a small result set (less than limit) there was an issue where max and current progress matched but not all info sets were downloaded.
This made the progress bar auto-reset and set the progress back by whatever it got. This fix disables the auto reset property

Signed-off-by: Nir Izraeli <nirizr@gmail.com>