### PR TITLE
Revert "Install correct django version in pip, depending on python ve…

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,12 +1,10 @@
-Django >=1.8, <2.0 ; python_version < '3.0' # celery 4.0 requires django 1.8
-                                            # django2 does not support python2
-Django ; python_version >= '3.0'            # install any django version on python3
+Django >= 1.8 # celery 4.0 requires django 1.8
 numpy
 scipy
 scikit-learn
 django-registration-redux
 djangorestframework
-django-rest-auth >=0.8.2
-celery >=4 # celery 4 broke backwards compatibility, we moved to using it
+django-rest-auth >= 0.8.2
+celery >= 4 # celery 4 broke backwards compatibility
 django-filter
 mysqlclient # this requires package installed libmysqlclient-dev


### PR DESCRIPTION
…rsion"

This reverts commit 1b9434daafafc7c1e2bd805309105b9f8da4b595.

PyPA team manually edited django 2.0.0 to require python >= 3.4
pypi no longer tries to install django 2 with python < 3
making this no longer nencessary