### PR TITLE
Fix several gui issues in MatchResultDialog

### DIFF
--- a/idaplugin/rematch/actions/base.py
+++ b/idaplugin/rematch/actions/base.py
@@ -127,7 +127,7 @@ class IDAAction(Action, ida_kernwin.action_handler_t):
     self._running = True
 
     if callable(self.ui_class):
-      self.ui = self.ui_class(self)
+      self.ui = self.ui_class(action=self)
       self.ui.show()
     else:
       raise NotImplementedError("activation called on an action class with no "

--- a/idaplugin/rematch/actions/match.py
+++ b/idaplugin/rematch/actions/match.py
@@ -266,7 +266,7 @@ class MatchAction(base.BoundFileAction):
 
     matches_url = "collab/tasks/{}/matches/".format(self.task_id)
     q = network.QueryWorker("GET", matches_url, json=True, pageable=True,
-                            params={'limit': 100})
+                            params={'limit': 200})
     q.start(self.handle_matches)
     self.delayed_queries.append(q)
 

--- a/idaplugin/rematch/network.py
+++ b/idaplugin/rematch/network.py
@@ -105,6 +105,8 @@ class QueryWorker(QtCore.QRunnable):
 
   def run_query(self):
     while self.running:
+      # TODO: Make pageable and/or splittable parallelable. meaning split pages
+      # to multiple queries to split to multiple concurrently executing queries
       # if we're running a splittable query, only send SPLIT parameters for the
       # splittable variable
       if self.splittable:


### PR DESCRIPTION
1. A bug on displaying all actions.
2. Setting focus back to match result dialog tree.
3. Checkbox state problems.
4. Set first checkbox instead of last.
5. Enable sorting.