### PR TITLE
Tighter import rematch exception handling

### DIFF
--- a/idaplugin/plugin_rematch.py
+++ b/idaplugin/plugin_rematch.py
@@ -1,7 +1,10 @@
 try:
     # required to run in IDA / python2
     import rematch
-except ImportError:
+except ImportError as ex:
+    # let all other ImportErrors pass through
+    if not ex.args[0] == "No module named 'rematch'":
+        raise
     # required to run in Travis / python3
     from . import rematch
 


### PR DESCRIPTION
to actually raise all ImportErrors other than the rematch module itself.